### PR TITLE
Installing root

### DIFF
--- a/1.7/administration/installing.md
+++ b/1.7/administration/installing.md
@@ -22,9 +22,9 @@ For users deploying to the public cloud, DC/OS offers configurable [cloud provis
 
 # Datacenter Installation
 
-For new users installing to existing virtual or physical machines, on-premise or in the cloud, the [Automated Installer][3] provides a guided experience for bootstrapping a DCOS cluster.
+For new users installing to existing virtual or physical machines, on-premises or in the cloud, the [Automated Installer][3] provides a guided experience for bootstrapping a DCOS cluster.
 
-For advanced users installing to existing virtual or physical machines, on-premise or in the cloud, the [Manual Installer][4] provides a scriptable, automatable interface to integrate with your preferred configuration management system.
+For advanced users installing to existing virtual or physical machines, on-premises or in the cloud, the [Manual Installer][4] provides a scriptable, automatable interface to integrate with your preferred configuration management system.
 
  [1]: /administration/installing/local
  [2]: /administration/installing/cloud


### PR DESCRIPTION
/cc @joel-hamill @williamsaaron @pyronicide @mhausenblas 

I know this doesn't match the /installing page layout, but our docs don't match that layout either...  So I went with "local" (vagrant), "cloud" (cloud provisioning templates), and "datacenter" (on existing virtual or physical machines).
