### PR TITLE
Fix link and add periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DC/OS Documentation
 Documentation for the Datacenter Operating System (DC/OS)
 
-These documents are used as source to generate <dcos.io>.
+These documents are used as source to generate [dcos.io](https://dcos.io/).
 
 [![Build Status](https://travis-ci.com/dcos/dcos-docs.svg?token=yAREgxuvuzZLg282ZE3m&branch=master)](https://travis-ci.com/dcos/dcos-docs)
 
@@ -15,16 +15,16 @@ Markdown in this repository is formatted for rendering with [Jekyll](https://jek
 
 - Links should include the full path relative to the root of dcos.io to allow easy search/replace. These links will not work in the github code browser.
 - All page links will be directories instead of files.
-- Index pages should reside next to any child directory they parent (rather than using Github's README.md indexing)
-- Page tables of contents will be automatically generated based on top-level headers
-- Directory tables of contents will be automatically generated based on post_titles and post_excerpts
+- Index pages should reside next to any child directory they parent (rather than using Github's README.md indexing).
+- Page tables of contents will be automatically generated based on top-level headers.
+- Directory tables of contents will be automatically generated based on post_titles and post_excerpts.
 
 ## Contributing
 
 Contribute to the docs using one of the following options:
 
-* Create a Github issue with a suggestion for a tutorial (for example: I'd like to see a tutorial on Apache Kafka)
-* Update or write a new doc yourself following the [Contributing Guidelines](CONTRIBUTING.md)
+* Create a Github issue with a suggestion for a tutorial (for example: I'd like to see a tutorial on Apache Kafka).
+* Update or write a new doc yourself following the [Contributing Guidelines](CONTRIBUTING.md).
 
 ## License and Authors
 


### PR DESCRIPTION
There is no actual link to dcos.io right now.