### PR TITLE
Indent tables to fix numbering

### DIFF
--- a/1.7/usage/service-discovery/custom-domain-service-discovery.md
+++ b/1.7/usage/service-discovery/custom-domain-service-discovery.md
@@ -38,69 +38,69 @@ DC/OS uses Mesos-DNS for internal service discovery. While the `.mesos` domain c
           "zk": "zk://<dcos_zookeeper1>,<dcos_zookeeper2>,<dcos_zookeeper3>:<dcos_zookeeper_port>/mesos"
         }
 
-<table class="table">
-  <tbody>
-    <tr>
-      <th class="confluenceTh">
-        Parameter
-      </th>
-
-      <th class="confluenceTh">
-        Description
-      </th>
-    </tr>
-
-    <tr>
-      <td>
-        domain
-      </td>
-
-      <td class="confluenceTd">
-        Your custom DNS suffix
-      </td>
-    </tr>
-
-    <tr>
-      <td class="confluenceTd">
-        listen_ip
-      </td>
-
-      <td class="confluenceTd">
-        IP to listen on (default 0.0.0.0)
-      </td>
-    </tr>
-
-    <tr>
-      <td class="confluenceTd">
-        dcos_master{1..3}
-      </td>
-
-      <td class="confluenceTd">
-        IP addresses of DC/OS masters
-      </td>
-    </tr>
-
-    <tr>
-      <td class="confluenceTd">
-        resolver{1..3}
-      </td>
-
-      <td class="confluenceTd">
-        Additional resolvers (at least one required)
-      </td>
-    </tr>
-
-    <tr>
-      <td class="confluenceTd">
-        dcos_zookeeper{1..3}
-      </td>
-
-      <td class="confluenceTd">
-        IP Addresses of ZooKeeper servers
-      </td>
-    </tr>
-  </tbody>
-</table>
+    <table class="table">
+      <tbody>
+        <tr>
+          <th class="confluenceTh">
+            Parameter
+          </th>
+    
+          <th class="confluenceTh">
+            Description
+          </th>
+        </tr>
+    
+        <tr>
+          <td>
+            domain
+          </td>
+    
+          <td class="confluenceTd">
+            Your custom DNS suffix
+          </td>
+        </tr>
+    
+        <tr>
+          <td class="confluenceTd">
+            listen_ip
+          </td>
+    
+          <td class="confluenceTd">
+            IP to listen on (default 0.0.0.0)
+          </td>
+        </tr>
+    
+        <tr>
+          <td class="confluenceTd">
+            dcos_master{1..3}
+          </td>
+    
+          <td class="confluenceTd">
+            IP addresses of DC/OS masters
+          </td>
+        </tr>
+    
+        <tr>
+          <td class="confluenceTd">
+            resolver{1..3}
+          </td>
+    
+          <td class="confluenceTd">
+            Additional resolvers (at least one required)
+          </td>
+        </tr>
+    
+        <tr>
+          <td class="confluenceTd">
+            dcos_zookeeper{1..3}
+          </td>
+    
+          <td class="confluenceTd">
+            IP Addresses of ZooKeeper servers
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
 3.  Download the latest Mesos-DNS binary and copy it to `/opt/mesos-dns-ext/mesos-dns`: <https://github.com/mesosphere/mesos-dns/releases>.
 
@@ -129,57 +129,57 @@ DC/OS uses Mesos-DNS for internal service discovery. While the `.mesos` domain c
           ]
         }
 
-<table class="table">
-  <tbody>
-    <tr>
-      <th class="confluenceTh">
-        Parameter
-      </th>
-
-      <th class="confluenceTh">
-        Definition
-      </th>
-    </tr>
-    <tr>
-      <td class="confluenceTd">
-        mesos_agent
-      </td>
-
-      <td class="confluenceTd">
-        A specific agent to pin Mesos-DNS to. Since Mesos-DNS will be acting as a delegate, its IP must remain static. For multiple Mesos-DNS instances (and redundancy), the LIKE constraint operator can be used to define hosts using regex. See <a href="https://mesosphere.github.io/marathon/docs/constraints.html" class="external-link" rel="nofollow">https://mesosphere.github.io/marathon/docs/constraints.html</a> for more information. As a best-practice, we also recommend using healthchecks to ensure that Mesos-DNS remains running.
-      </td>
-    </tr>
-  </tbody>
-</table>
+    <table class="table">
+      <tbody>
+        <tr>
+          <th class="confluenceTh">
+            Parameter
+          </th>
+    
+          <th class="confluenceTh">
+            Definition
+          </th>
+        </tr>
+        <tr>
+          <td class="confluenceTd">
+            mesos_agent
+          </td>
+    
+          <td class="confluenceTd">
+            A specific agent to pin Mesos-DNS to. Since Mesos-DNS will be acting as a delegate, its IP must remain static. For multiple Mesos-DNS instances (and redundancy), the LIKE constraint operator can be used to define hosts using regex. See <a href="https://mesosphere.github.io/marathon/docs/constraints.html" class="external-link" rel="nofollow">https://mesosphere.github.io/marathon/docs/constraints.html</a> for more information. As a best-practice, we also recommend using healthchecks to ensure that Mesos-DNS remains running.
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
 5.  Create a new application for Mesos-DNS in Marathon:
 
         $ curl -X POST -H 'Content-Type: application/json' -d @mesos-dns-ext.json http://<marathon>:8080/v2/apps
 
 
-<table class="table">
-  <tbody>
-    <tr>
-      <th class="confluenceTh">
-        Parameter
-      </th>
-
-      <th class="confluenceTh">
-        Definition
-      </th>
-    </tr>
-
-    <tr>
-      <td class="confluenceTd">
-        marathon
-      </td>
-
-      <td class="confluenceTd">
-        IP/hostname of Marathon leader
-      </td>
-    </tr>
-  </tbody>
-</table>
+    <table class="table">
+      <tbody>
+        <tr>
+          <th class="confluenceTh">
+            Parameter
+          </th>
+    
+          <th class="confluenceTh">
+            Definition
+          </th>
+        </tr>
+    
+        <tr>
+          <td class="confluenceTd">
+            marathon
+          </td>
+    
+          <td class="confluenceTd">
+            IP/hostname of Marathon leader
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
 ## DNS Configuration
 
@@ -191,39 +191,39 @@ DC/OS uses Mesos-DNS for internal service discovery. While the `.mesos` domain c
         <domain> IN NS ns1.<domain>
 
 
-<table class="table">
-  <tbody>
-    <tr>
-      <th class="confluenceTh">
-        Parameter
-      </th>
-
-      <th class="confluenceTh">
-        Definition
-      </th>
-    </tr>
-
-    <tr>
-      <td class="confluenceTd">
-        domain
-      </td>
-
-      <td class="confluenceTd">
-        <span>Your custom DNS suffix</span>
-      </td>
-    </tr>
-
-    <tr>
-      <td class="confluenceTd">
-        mesos_dns_ext
-      </td>
-
-      <td class="confluenceTd">
-        IP Address of the Mesos Agent that Mesos-DNS is running on (<em>see DC/OS Configuration, <a href="#four">Step 4</a>, <mesos_agent></em>).
-      </td>
-    </tr>
-  </tbody>
-</table>
+    <table class="table">
+      <tbody>
+        <tr>
+          <th class="confluenceTh">
+            Parameter
+          </th>
+    
+          <th class="confluenceTh">
+            Definition
+          </th>
+        </tr>
+    
+        <tr>
+          <td class="confluenceTd">
+            domain
+          </td>
+    
+          <td class="confluenceTd">
+            <span>Your custom DNS suffix</span>
+          </td>
+        </tr>
+    
+        <tr>
+          <td class="confluenceTd">
+            mesos_dns_ext
+          </td>
+    
+          <td class="confluenceTd">
+            IP Address of the Mesos Agent that Mesos-DNS is running on (<em>see DC/OS Configuration, <a href="#four">Step 4</a>, <mesos_agent></em>).
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
 ## Example
 


### PR DESCRIPTION
The numbering on https://dcos.io/docs/1.7/usage/service-discovery/custom-domain-service-discovery/ is getting messed up as the tables are not indented. Steps 3 and 4 are getting numbered as 1 and 2. Similarly for step 5, its getting numbered as 1

I have intended all the tables on the page for desired result.
