### PR TITLE
Remove downgrade text.

### DIFF
--- a/1.7/usage/cli/update.md
+++ b/1.7/usage/cli/update.md
@@ -4,7 +4,7 @@ nav_title: Updates
 menu_order: 3
 ---
 
-You can update the DC/OS CLI to the latest version or downgrade to an older version.
+You can update the DC/OS CLI to the latest version.
 
 # Upgrade the CLI
 
@@ -15,23 +15,3 @@ You can upgrade an existing DC/OS CLI installation to the latest build. Before r
     ```bash
     $ sudo pip install -U dcoscli
     ```
-
-
-# Downgrade the CLI
-
-You can downgrade an existing DC/OS CLI installation to an older version.
-
-**Tip:** Downgrading is necessary if you are running an older version of DC/OS and want to reinstall the DC/OS CLI.
-
-1.  Delete your DC/OS CLI installation directories:
-
-    ```bash
-    $ sudo rm -rf dcos && rm -rf ~/.dcos
-    ```
-
-2.  Install the legacy version of the DC/OS CLI, where <public-master-ip> is the public IP of your master node:
-
-        mkdir -p dcos && cd dcos &&
-          curl -O https://downloads.mesosphere.com/dcos-cli/install-legacy.sh &&
-          bash ./install-legacy.sh . <public-master-ip> &&
-          source ./bin/env-setup


### PR DESCRIPTION
These instructions aren't necessary for DC/OS since the legacy version is only necessary for versions 1.6 and older.

It is still available in the official Mesosphere documentation: https://docs.mesosphere.com/usage/cli/update/
