### PR TITLE
Use full path to ip

### DIFF
--- a/1.7/administration/installing/custom/advanced.md
+++ b/1.7/administration/installing/custom/advanced.md
@@ -94,7 +94,7 @@ The DC/OS installation creates these folders:
         #!/usr/bin/env bash
         set -o nounset -o errexit
         export PATH=/usr/sbin:/usr/bin:$PATH
-        echo $(ip addr show eth0 | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
+        echo $(/usr/sbin/ip addr show eth0 | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
         ```
 
     *   #### Use the network route to the Mesos master


### PR DESCRIPTION
Use full path to `ip` . If you don't some things might fail. Kafka brokers failed in one instance. 