### PR TITLE
Updated the external volume support link.

### DIFF
--- a/1.7/overview/roadmap.md
+++ b/1.7/overview/roadmap.md
@@ -31,8 +31,7 @@ This effort plans to integrate edge load balancing into the [DC/OS service disco
 
 ### Pluggable External Volumes
 Support for pluggable external volume providers such as [REX-Ray](https://github.com/emccode/rexray), [Flocker](https://github.com/ClusterHQ/flocker), etc.
-See the [design doc for external volumes in Mesos](https://docs.google.com/document/d/1sSgPh_0Muvdec0__q9Ecs8Uq0qvEuETs0AGinevOr3w/edit) and
-[external volumes in Marathon](https://mesosphere.github.io/marathon/docs/external-volumes.html).
+See the [design doc for external volumes (Docker Volume Driver) in Mesos](https://docs.google.com/document/d/1uhi1lf1_sEmnl0HaqHUCsqPb9m9jOKbRlXYW1S-tZis/edit?usp=sharing) and [external volumes in Marathon](https://mesosphere.github.io/marathon/docs/external-volumes.html).
 
 ## Medium Term
 


### PR DESCRIPTION
The link for external volume is not right, we should update it to docker volume driver design document link.