### PR TITLE
Archive install files and add public agent

### DIFF
--- a/1.7/administration/installing/custom/cli.md
+++ b/1.7/administration/installing/custom/cli.md
@@ -308,9 +308,19 @@ To install DC/OS:
 
     ![dashboard](../img/ui-dashboard.gif)
 
+8. Archive your installer files for safe-keeping. You'll need this archive to make new agents, including the [public agent][11].
+
+    ```bash
+    # <Ctrl-C> to exit installer
+    $ cd genconf/serve
+    $ sudo tar cf dcos-install.tar *
+    # Move the dcos-install.tar file to a safe place
+    ```
+
 # Next Steps
 
 - [Add users to your cluster][10]
+- [Add a public agent][11]
 - [Install the DC/OS Command-Line Interface (CLI)][2]
 - [Troubleshooting DC/OS installation][9]
 - [Use your cluster][8]
@@ -351,3 +361,4 @@ After DC/OS is installed and deployed across your cluster, you can add more agen
  [8]: /docs/1.7/usage/
  [9]: /docs/1.7/administration/installing/custom/troubleshooting/
  [10]: /docs/1.7/administration/user-management/
+ [11]: /docs/1.7/administration/installing/custom/create-public-agent/

--- a/1.7/administration/installing/custom/cli.md
+++ b/1.7/administration/installing/custom/cli.md
@@ -304,10 +304,6 @@ To install DC/OS:
 
     ![alt text](../img/ui-installer-login.gif)
 
-    You are done!
-
-    ![dashboard](../img/ui-dashboard.gif)
-
 8. Archive your installer files for safe-keeping. You'll need this archive to make new agents, including the [public agent][11].
 
     ```bash
@@ -316,6 +312,11 @@ To install DC/OS:
     $ sudo tar cf dcos-install.tar *
     # Move the dcos-install.tar file to a safe place
     ```
+    
+    You are done!
+
+    ![dashboard](../img/ui-dashboard.gif)
+
 
 # Next Steps
 

--- a/1.7/administration/installing/custom/create-public-agent.md
+++ b/1.7/administration/installing/custom/create-public-agent.md
@@ -1,0 +1,72 @@
+---
+post_title: Converting a Private Node to Public  
+layout: page
+published: true
+---
+
+In DC/OS, we distinguish between agents that are accessible from the cloud and those which are not with the notion of "public agents". By default, agent nodes are designated as private during [GUI](/administration/installing/custom/gui/) or [CLI](/administration/installing/custom/cli/) installation.
+
+You can determine the count of public agents in your cluster by running the following command. A result of 0 means that you do not have a public agent, as shown below:
+
+    ```bash
+    $ curl -skSL -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/mesos/master/slaves | jq '.slaves[] | .reserved_resources' | grep slave_public | wc -l
+           0
+    ```
+
+### Prerequisites:
+
+1. DC/OS is installed and you have deployed at least one private agent node.
+
+### Converting private agents to public:
+
+**The following steps must be taken on a machine that is currently a DC/OS node. If this node is currently running tasks, those tasks will be terminated in this process.**
+
+1.  Uninstall the current DC/OS software on the agent node.
+
+    ```bash
+    $ sudo -i /opt/mesosphere/bin/pkgpanda uninstall
+    $ sudo systemctl stop dcos-mesos-slave
+    $ sudo systemctl disable dcos-mesos-slave
+    ```
+
+1.  Remove the old directory structures on the agent node.
+
+    ```bash
+    $ sudo rm -rf /opt/mesosphere /var/lib/mesos
+    ```
+
+1.  Restart the machine.
+
+    ```bash
+    $sudo reboot
+    ```
+
+### Install DC/OS
+
+1.  Copy the `dcos-install.tar` file created in the GUI or CLI installation method to the machine that will be a public agent.
+
+    ```bash
+    $ ssh $USER@$AGENT "sudo mkdir -p /opt/dcos_install_tmp"
+    $ scp ~/dcos-install.tar $ROOT_USER@$AGENT:~/dcos-install.tar
+    ```
+
+1.  SSH to the machine:
+
+    ```bash
+    $ ssh $USER@$AGENT
+    ```
+
+1.  Install DC/OS as a public agent:
+
+    ```bash
+    $ sudo mv ~/dcos-install.tar /opt/dcos_install_tmp
+    $ sudo bash /opt/dcos_install_tmp/dcos_install.sh slave_public
+    ```
+
+1.  Verify that your new agent node is public by running this command from DC/OS CLI.
+
+    ```bash
+    $ curl -skSL -H "Authorization: token=$(dcos config show core.dcos_acs_token)" $(dcos config show core.dcos_url)/mesos/master/slaves | jq '.slaves[] | .reserved_resources' | grep slave_public | wc -l
+    ```
+
+    You should see an output greater than zero to indicate at least one public agent.

--- a/1.7/administration/installing/custom/create-public-agent.md
+++ b/1.7/administration/installing/custom/create-public-agent.md
@@ -1,7 +1,7 @@
 ---
-post_title: Converting a Private Node to Public  
-layout: page
-published: true
+post_title: Creating a Public Agent
+nav_title: Public Agent
+menu_order: 8
 ---
 
 In DC/OS, we distinguish between agents that are accessible from the cloud and those which are not with the notion of "public agents". By default, agent nodes are designated as private during [GUI](/administration/installing/custom/gui/) or [CLI](/administration/installing/custom/cli/) installation.

--- a/1.7/administration/installing/custom/gui.md
+++ b/1.7/administration/installing/custom/gui.md
@@ -113,14 +113,24 @@ The DC/OS installation creates these folders:
 8.  Click **Log In To DC/OS**. If this doesn't work, take a look at the [troubleshooting docs][9]
 
     ![login](../img/dcos-gui-login.png)
-    
+
+9. Archive your installer files for safe-keeping. You'll need this archive to make new agents, including the [public agent][4].
+
+    ```bash
+    # <Ctrl-C> to exit installer
+    $ cd genconf/serve
+    $ sudo tar cf dcos-install.tar *
+    # Move the dcos-install.tar file to a safe place
+    ```
+
     You are done!
-    
+
     ![dashboard](../img/ui-dashboard.gif)
 
 ## Next Steps
 
 - [Add users to your cluster][10]
+- [Add a public agent][4]
 - [Install the DC/OS Command-Line Interface (CLI)][5]
 - [Troubleshooting DC/OS installation][9]
 - [Using your cluster][6]
@@ -129,9 +139,9 @@ The DC/OS installation creates these folders:
 [1]: https://downloads.dcos.io/dcos/EarlyAccess/dcos_generate_config.sh
 [2]: /docs/1.7/overview/service-discovery/
 [3]: /docs/1.7/administration/installing/custom/system-requirements/
+[4]: /docs/1.7/administration/installing/custom/create-public-agent/
 [5]: /docs/1.7/usage/cli/install/
 [6]: /docs/1.7/usage/
 [7]: /docs/1.7/administration/installing/custom/uninstall/
 [9]: /docs/1.7/administration/installing/custom/troubleshooting/
 [10]: /docs/1.7/administration/user-management/
-

--- a/1.7/administration/installing/custom/index.md
+++ b/1.7/administration/installing/custom/index.md
@@ -1,7 +1,7 @@
 ---
 post_title: DC/OS Custom Installation Options
 nav_title: Custom
-menu_order: 3
+menu_order: 1
 ---
 
 You can install DC/OS on bare metal, virtual machines and every cloud. With the custom installers, you have the flexibility to configure each installation of DC/OS exactly how you like it.


### PR DESCRIPTION
Instructions added to GUI and CLI install methods to capture the install files after install completes, and a new page that covers taking these files to a new machine and setting up a public agent.
