### PR TITLE
Fix broken IP script

### DIFF
--- a/1.7/administration/installing/custom/advanced.md
+++ b/1.7/administration/installing/custom/advanced.md
@@ -107,11 +107,13 @@ The DC/OS installation creates these folders:
 
         ```bash
         #!/usr/bin/env bash
-        set -o nounset -o errexit
+        set -o nounset -o errexit -o pipefail
+        export PATH=/sbin:/usr/sbin:/bin:/usr/bin:$PATH
 
         MASTER_IP=172.28.128.3
+        INTERFACE_IP=$(ip r g ${MASTER_IP:-8.8.8.8} | awk 'BEGIN {ec=1} {if($6=="src") {print $7; ec=0; exit}} END {exit ec}')
 
-        echo $(/usr/sbin/ip route show to match 172.28.128.3 | grep -Eo '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}' | tail -1)
+        echo $INTERFACE_IP
         ```
 
 # Install DC/OS

--- a/1.7/administration/installing/custom/cli.md
+++ b/1.7/administration/installing/custom/cli.md
@@ -81,11 +81,13 @@ The DC/OS installation creates these folders:
 
         ```bash
         #!/usr/bin/env bash
-        set -o nounset -o errexit
+        set -o nounset -o errexit -o pipefail
+        export PATH=/sbin:/usr/sbin:/bin:/usr/bin:$PATH
 
         MASTER_IP=172.28.128.3
+        INTERFACE_IP=$(ip r g ${MASTER_IP:-8.8.8.8} | awk 'BEGIN {ec=1} {if($6=="src") {print $7; ec=0; exit}} END {exit ec}')
 
-        echo $(/usr/sbin/ip route show to match 172.28.128.3 | grep -Eo '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}' | tail -1)
+        echo $INTERFACE_IP
         ```
 
 1.  Create a configuration file and save as `genconf/config.yaml`.


### PR DESCRIPTION
The script in `Use the network route to the Mesos master` is not doing what is described.

Instead of returning the interface IP it returns the gateway IP. Also it defines a variable `$MASTER_IP` but never uses it. Instead the IP is duplicated in the command. The `echo $()` would also make it so the script always exits with code 0 even when no valid IP could be found.

This PR fixes that. Also if no MASTER_IP is specified it uses the IP of which ever interface is connected to a default gateway.

```
[lukas@lukas.users ~]$ MASTER_IP=172.28.128.3
[lukas@lukas.users ~]$ echo $(/usr/sbin/ip route show to match 172.28.128.3 | grep -Eo '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}' | tail -1)
192.168.200.1
[lukas@lukas.users ~]$ echo $(ip r g ${MASTER_IP:-8.8.8.8} | awk 'BEGIN {ec=1} {if($6=="src") {print $7; ec=0; exit}} END {exit ec}')
192.168.200.114
```
