### PR TITLE
Update IP detect script

### DIFF
--- a/1.7/administration/installing/custom/advanced.md
+++ b/1.7/administration/installing/custom/advanced.md
@@ -109,10 +109,23 @@ The DC/OS installation creates these folders:
         #!/usr/bin/env bash
         set -o nounset -o errexit -o pipefail
         export PATH=/sbin:/usr/sbin:/bin:/usr/bin:$PATH
-
-        MASTER_IP=172.28.128.3
-        INTERFACE_IP=$(ip r g ${MASTER_IP:-8.8.8.8} | awk 'BEGIN {ec=1} {if($6=="src") {print $7; ec=0; exit}} END {exit ec}')
-
+        MASTER_IP=$(dig +short master.mesos || true)
+        MASTER_IP=${MASTER_IP:-172.28.128.3}
+        INTERFACE_IP=$(ip r g ${MASTER_IP} | \
+        awk -v master_ip=${MASTER_IP} '
+        BEGIN { ec = 1 }
+        {
+          if($1 == master_ip) {
+            print $7
+            ec = 0
+          } else if($1 == "local") {
+            print $6
+            ec = 0
+          }
+          if (ec == 0) exit;
+        }
+        END { exit ec }
+        ')
         echo $INTERFACE_IP
         ```
 

--- a/1.7/administration/installing/custom/cli.md
+++ b/1.7/administration/installing/custom/cli.md
@@ -83,10 +83,23 @@ The DC/OS installation creates these folders:
         #!/usr/bin/env bash
         set -o nounset -o errexit -o pipefail
         export PATH=/sbin:/usr/sbin:/bin:/usr/bin:$PATH
-
-        MASTER_IP=172.28.128.3
-        INTERFACE_IP=$(ip r g ${MASTER_IP:-8.8.8.8} | awk 'BEGIN {ec=1} {if($6=="src") {print $7; ec=0; exit}} END {exit ec}')
-
+        MASTER_IP=$(dig +short master.mesos || true)
+        MASTER_IP=${MASTER_IP:-172.28.128.3}
+        INTERFACE_IP=$(ip r g ${MASTER_IP} | \
+        awk -v master_ip=${MASTER_IP} '
+        BEGIN { ec = 1 }
+        {
+          if($1 == master_ip) {
+            print $7
+            ec = 0
+          } else if($1 == "local") {
+            print $6
+            ec = 0
+          }
+          if (ec == 0) exit;
+        }
+        END { exit ec }
+        ')
         echo $INTERFACE_IP
         ```
 


### PR DESCRIPTION
Fixes a bug where the script would not output the interface IP if the MASTER_IP was the same as the local interface IP. I.e. if the script was run on the master that was entered in MASTER_IP. This now also auto detects the master IP on agent nodes.