### PR TITLE
how to print node details

### DIFF
--- a/1.7/administration/logging/elk.md
+++ b/1.7/administration/logging/elk.md
@@ -1,5 +1,5 @@
 ---
-post_title: Log Management in DC/OS with ELK
+post_title: Log Management with ELK
 nav_title: ELK
 menu_order: 1
 ---

--- a/1.7/administration/logging/filter-elk.md
+++ b/1.7/administration/logging/filter-elk.md
@@ -1,5 +1,5 @@
 ---
-post_title: Filtering DC/OS Task Logs with ELK
+post_title: Filtering Logs with ELK
 nav_title: Filtering ELK
 menu_order: 2
 ---

--- a/1.7/administration/logging/filter-splunk.md
+++ b/1.7/administration/logging/filter-splunk.md
@@ -1,6 +1,6 @@
 ---
-post_title: Filtering DC/OS Task Logs with Splunk
-nav_title: Fitlering Splunk
+post_title: Filtering Logs with Splunk
+nav_title: Filtering Splunk
 menu_order: 4
 ---
 The file system paths of DC/OS task logs contain information such as the agent ID, framework ID, and executor ID. You can use this information to filter the log output for specific tasks, applications, or agents.

--- a/1.7/administration/logging/splunk.md
+++ b/1.7/administration/logging/splunk.md
@@ -1,5 +1,5 @@
 ---
-post_title: Log Management in DC/OS with Splunk
+post_title: Log Management with Splunk
 nav_title: Splunk
 menu_order: 3
 ---

--- a/1.7/overview/architecture.md
+++ b/1.7/overview/architecture.md
@@ -1,5 +1,5 @@
 ---
-post_title: The Architecture of DC/OS
+post_title: Architecture
 nav_title: Architecture
 menu_order: 2
 ---

--- a/1.7/overview/components.md
+++ b/1.7/overview/components.md
@@ -1,5 +1,5 @@
 ---
-post_title: "An Introduction to DC/OS Components"
+post_title: Components
 nav_title: Components
 menu_order: 4
 ---

--- a/1.7/overview/concepts.md
+++ b/1.7/overview/concepts.md
@@ -1,5 +1,5 @@
 ---
-post_title: The Concepts of DC/OS
+post_title: Concepts
 nav_title: Concepts
 menu_order: 5
 ---

--- a/1.7/overview/design/azure-container-service.md
+++ b/1.7/overview/design/azure-container-service.md
@@ -1,6 +1,6 @@
 ---
 post_title: >
-    DC/OS reference implementation: The Azure Container Service
+    Reference implementation: The Azure Container Service
 nav_title: Reference Implementation ACS
 menu_order: 1
 ---

--- a/1.7/overview/design/dcos-api.md
+++ b/1.7/overview/design/dcos-api.md
@@ -1,5 +1,5 @@
 ---
-post_title: DC/OS API Design
+post_title: API Design
 nav_title: API
 menu_order: 2
 ---

--- a/1.7/overview/design/index.md
+++ b/1.7/overview/design/index.md
@@ -1,5 +1,5 @@
 ---
-post_title: DC/OS Design
+post_title: Design
 nav_title: Design
 menu_order: 10
 ---

--- a/1.7/overview/features.md
+++ b/1.7/overview/features.md
@@ -1,5 +1,5 @@
 ---
-post_title: The Features of DC/OS
+post_title: Features
 nav_title: Features
 menu_order: 3
 ---

--- a/1.7/overview/high-availability.md
+++ b/1.7/overview/high-availability.md
@@ -1,5 +1,5 @@
 ---
-post_title: High Availability in DC/OS
+post_title: High Availability
 nav_title: High Availability
 menu_order: 6
 ---

--- a/1.7/overview/roadmap.md
+++ b/1.7/overview/roadmap.md
@@ -1,5 +1,5 @@
 ---
-post_title: DC/OS Roadmap
+post_title: Roadmap
 nav_title: Roadmap
 menu_order: 9
 ---

--- a/1.7/overview/security.md
+++ b/1.7/overview/security.md
@@ -1,5 +1,5 @@
 ---
-post_title: Security in DC/OS
+post_title: Security
 nav_title: Security
 menu_order: 7
 ---

--- a/1.7/usage/cli/index.md
+++ b/1.7/usage/cli/index.md
@@ -1,5 +1,5 @@
 ---
-post_title: DC/OS Command Line Interface
+post_title: CLI
 nav_title: CLI
 menu_order: 2
 ---

--- a/1.7/usage/managing-services/install.md
+++ b/1.7/usage/managing-services/install.md
@@ -1,5 +1,5 @@
 ---
-post_title: Installing a service
+post_title: Installing Services
 nav_title: Installing
 menu_order: 000
 ---

--- a/1.7/usage/managing-services/list.md
+++ b/1.7/usage/managing-services/list.md
@@ -1,5 +1,5 @@
 ---
-post_title: Monitoring installed services
+post_title: Monitoring Services
 nav_title: Monitoring
 menu_order: 003
 ---

--- a/1.7/usage/service-discovery/index.md
+++ b/1.7/usage/service-discovery/index.md
@@ -1,5 +1,5 @@
 ---
-post_title: Service Discovery
+post_title: Service Discovery and Load Balancing
 nav_title: Service Discovery
 menu_order: 3
 ---

--- a/1.7/usage/service-discovery/index.md
+++ b/1.7/usage/service-discovery/index.md
@@ -1,5 +1,5 @@
 ---
-post_title: Service Discovery and Load Balancing in DC/OS
+post_title: Service Discovery
 nav_title: Service Discovery
 menu_order: 3
 ---

--- a/1.7/usage/webinterface.md
+++ b/1.7/usage/webinterface.md
@@ -1,5 +1,5 @@
 ---
-post_title: DC/OS Web Graphical User Interface
+post_title: GUI
 nav_title: GUI
 menu_order: 1
 ---


### PR DESCRIPTION
What do you think about these shortened titles? We currently seem to overuse a lot of "DC/OS" instances.
