### PR TITLE
Fixed marathon-lb menu order

### DIFF
--- a/1.7/usage/service-discovery/marathon-lb/advanced.md
+++ b/1.7/usage/service-discovery/marathon-lb/advanced.md
@@ -1,7 +1,6 @@
 ---
 post_title: Advanced Features
-post_excerpt: ""
-layout: docs.jade
+menu_order: 20
 ---
 ## HAProxy configuration
 

--- a/1.7/usage/service-discovery/marathon-lb/usage.md
+++ b/1.7/usage/service-discovery/marathon-lb/usage.md
@@ -1,7 +1,7 @@
 ---
 post_title: Getting Started with marathon-lb
 nav_title: Getting Started
-menu_order: 1
+menu_order: 10
 ---
 To demonstrate marathon-lb, you can boot a DC/OS cluster on AWS to run an internal and external load balancer. The external load balancer will be used for routing external HTTP traffic into the cluster, and the internal load balancer will be used for internal service discovery and load balancing. Since we’ll be doing this on AWS, external traffic will first hit an external load balancer configured to expose our "public" agent nodes.
 


### PR DESCRIPTION
this should fix the menu order on the enterprise site.
