### PR TITLE
Update docs on securing clusters.

### DIFF
--- a/1.7/administration/id-and-access-mgt/configure-your-security.md
+++ b/1.7/administration/id-and-access-mgt/configure-your-security.md
@@ -3,9 +3,6 @@ post_title: Configuring Your Security
 menu_order: 1
 ---
 
-## Using your own certificate for Admin Router
-We encourage administrators to replace the SSL certificate used by Admin Router on the master nodes. Refer to the [Nginx documentation](http://nginx.org/en/docs/http/configuring_https_servers.html) and the Admin Router configuration file at `/opt/mesosphere/active/adminrouter/nginx/conf/nginx.conf` on the master nodes. For more information on creating your certificate, see [Let's Encrypt](https://letsencrypt.org/).
-
 ### Using your own Auth0 account
 
 For improved security, administrators can choose to configure their own Auth0

--- a/1.7/administration/managing-aws.md
+++ b/1.7/administration/managing-aws.md
@@ -74,6 +74,6 @@ To upgrade a DC/OS cluster:
 
 3.  Shutdown your existing DC/OS cluster.
 
- [1]: /docs/1.7/overview/security/
+ [1]: /docs/1.7/administration/securing-your-cluster/
  [2]: /docs/latest/administration/installing/cloud/aws/
  [3]: https://console.aws.amazon.com/cloudformation/home

--- a/1.7/administration/securing-your-cluster.md
+++ b/1.7/administration/securing-your-cluster.md
@@ -1,6 +1,6 @@
 ---
-post_title: Security
-nav_title: Security
+post_title: Securing Your Cluster
+nav_title: Securing Your Cluster
 menu_order: 7
 ---
 
@@ -29,6 +29,44 @@ the other nodes in the cluster via URL routing. For security, the DC/OS cloud
 template allows configuring a whitelist so that only specific IP address
 ranges are permitted to access the admin zone.
 
+#### Steps for Securing Admin Router
+
+By default, Admin Router will permit unencrypted HTTP traffic. This is not
+considered secure, and you must provide a valid TLS certificate and redirect
+all HTTP traffic to HTTPS in order to properly secure access to your cluster.
+
+Once you have a valid TLS certificate, install the certificate on each master.
+Copy the certificate and private key to a well known location, such as under
+`/etc/ssl/certs`. It's suggested that you change the permissions of the
+private key to not be world-readable. Edit the Admin Router `nginx.conf`, by
+opening the file located at
+`/opt/mesosphere/active/adminrouter/nginx/conf`. Modify the nginx
+configuration `server` section, to look like this:
+
+```
+  server {
+    listen 80 default_server;
+    server_name _;
+    return 301 https://$host$request_uri;
+  }
+
+  server {
+      listen 443 ssl spdy default_server;
+      ssl_certificate /etc/ssl/certs/your-cert.crt;
+      ssl_certificate_key /etc/ssl/certs/your-key.key;
+
+      # rest of config intentionally omitted
+```
+
+In the block above, we're adding a new `server` section above the existing one
+which will redirect all HTTP traffic to HTTPS. We've also removed the
+`listen 80 ...` directive from the second server section. After making the
+changes, restart Admin Router:
+
+```console
+# systemctl restart dcos-adminrouter
+```
+
 ### Private zone
 
 The **private** zone is a non-routable network that is only accessible from
@@ -46,6 +84,14 @@ The agent nodes in the public zone are labeled with a special role so that
 only specific tasks can be scheduled here. These agent nodes have both public
 and private IP addresses and only specific ports should be open in their
 iptables firewall.
+
+By default, when using the cloud-based installers such as the AWS
+CloudFormation templates, a large number of ports are exposed to the Internet
+for the public zone. In production systems, it is unlikely that you would
+expose all of these ports. It's recommended that you close all ports except
+80 and 443 (for HTTP/HTTPS traffic) and use
+[marathon-lb](/docs/1.7/usage/service-discovery/marathon-lb/) with HTTPS for
+managing ingress traffic.
 
 ### Typical AWS deployment
 

--- a/1.7/development/index.md
+++ b/1.7/development/index.md
@@ -82,7 +82,7 @@ The following are a set of guidelines that should be considered when creating a 
 
  [1]: http://mesosphere.github.io/universe/
  [2]: http://mesosphere.github.io/universe/#publish-a-package-1
- [3]: /docs/1.7/overview/security/
+ [3]: /docs/1.7/administration/securing-your-cluster/
  [4]: https://github.com/mesosphere/universe
  [5]: http://mesosphere.github.io/universe/#submit-your-package
  [6]: https://github.com/mesosphere/dcos-helloworld

--- a/1.7/usage/index.md
+++ b/1.7/usage/index.md
@@ -4,12 +4,12 @@ menu_order: 3
 ---
 
 # Getting Started
-After you have [installed](/docs/1.7/administration/installing/) DC/OS and set up the CLI on your local machine, you should familiarize yourself with the DC/OS UI [Dashboard](/docs/1.7/usage/webinterface/) and DC/OS [CLI](/docs/1.7/usage/cli/). 
+After you have [installed](/docs/1.7/administration/installing/) DC/OS and set up the CLI on your local machine, you should familiarize yourself with the DC/OS UI [Dashboard](/docs/1.7/usage/webinterface/) and DC/OS [CLI](/docs/1.7/usage/cli/).
 
 You can then launch a production-grade, highly available, containerized nginx web server with a single command from the DC/OS CLI. DC/OS keeps your web server running if it crashes, allows you to scale it via the user interface and update its config at runtime, and much more!
 
 1.  Run this command to launch a containerized [sample](https://dcos.io/docs/1.7/usage/nginx.json) app on DC/OS.
-    
+
     ```bash
     $ dcos marathon app add https://dcos.io/docs/1.7/usage/nginx.json
     ```
@@ -44,7 +44,7 @@ If you want to learn more about how DC/OS works:
 
 - Check out the [DC/OS Architecture](/docs/1.7/overview/architecture/)
 - Learn how [High Availability](/docs/1.7/overview/high-availability/) is achieved in DC/OS
-- Understand [Network Security](/docs/1.7/overview/security/) in DC/OS
+- Understand [Network Security](/docs/1.7/administration/securing-your-cluster/) in DC/OS
 
 If you have a DevOps role:
 
@@ -58,5 +58,3 @@ If you have a DC/OS administrator role:
 - [Load-balancing](/docs/1.7/usage/service-discovery/marathon-lb/) with DC/OS
 
 If you are now a seasoned DC/OS user and want to adapt or extend DC/OS, you can learn how to [contribute](/contribute)!
-
-


### PR DESCRIPTION
 - renamed & relocated security doc
 - added instructions on redirecting HTTP to HTTPS with adminrouter
 - added note about open ports on public agents with CF templates