### PR TITLE
Use lowercase only for HAPROXY_0_VHOST label value

### DIFF
--- a/1.7/usage/service-discovery/marathon-lb/usage.md
+++ b/1.7/usage/service-discovery/marathon-lb/usage.md
@@ -203,7 +203,7 @@ Modify the external nginx app to look like this:
       }],
       "labels":{
         "HAPROXY_GROUP":"external",
-        "HAPROXY_0_VHOST":"brenden-j-PublicSl-1LTLKZEH6B2G6-1145355943.us-west-2.elb.amazonaws.com"
+        "HAPROXY_0_VHOST":"brenden-j-publicsl-1ltlkzeh6b2g6-1145355943.us-west-2.elb.amazonaws.com"
       }
     }
 


### PR DESCRIPTION
I followed the doc and was not able to make the VHOST setting work until I changed the label value to all lowercase. Updated the marathon JSON to reflect it. 

CC @brndnmtthws for review. 