### PR TITLE
Docker 1.12 no longer uses socket activation

### DIFF
--- a/1.7/administration/installing/cloud/oracle/index.md
+++ b/1.7/administration/installing/cloud/oracle/index.md
@@ -178,7 +178,7 @@ These steps assume that you've spun up the bootstrap instance and that you are l
   $ sudo mkdir -p /etc/systemd/system/docker.service.d && sudo tee /etc/systemd/system/docker.service.d/override.conf <<EOF
   [Service]
   ExecStart=
-  ExecStart=/usr/bin/docker daemon --storage-driver=overlay -H fd://
+  ExecStart=/usr/bin/docker daemon --storage-driver=overlay
   EOF
   ```
 


### PR DESCRIPTION
Docker 1.12 on CentOS no longer uses socket activation. It fails if the option is added
