### PR TITLE
use --remote-name when downloading dcos binary.

### DIFF
--- a/1.8/usage/cli/install.md
+++ b/1.8/usage/cli/install.md
@@ -24,7 +24,7 @@ The recommended method to install the DC/OS CLI is by clicking the quick-launch 
 1.  Download the DC/OS CLI binary (`dcos`) to your local directory (for example, `/usr/local/bin/`).
 
     ```bash
-    $ curl --remote-name https://downloads.dcos.io/binaries/cli/linux/x86-64/0.4.10/dcos
+    $ curl -O https://downloads.dcos.io/binaries/cli/linux/x86-64/0.4.10/dcos
     ```
     
     **Important:** The CLI must be installed on a system that is external to your DC/OS cluster.
@@ -86,7 +86,7 @@ The recommended method to install the DC/OS CLI is by clicking the quick-launch 
 1.  Download the DC/OS CLI binary (`dcos`) to your local directory (for example, `/usr/local/bin/`).
 
     ```bash
-    $ curl https://downloads.dcos.io/binaries/cli/darwin/x86-64/0.4.10/dcos
+    $ curl -O https://downloads.dcos.io/binaries/cli/darwin/x86-64/0.4.10/dcos
     ```
     
     **Important:** The CLI must be installed on a system that is external to your DC/OS cluster.

--- a/1.8/usage/cli/install.md
+++ b/1.8/usage/cli/install.md
@@ -24,7 +24,7 @@ The recommended method to install the DC/OS CLI is by clicking the quick-launch 
 1.  Download the DC/OS CLI binary (`dcos`) to your local directory (for example, `/usr/local/bin/`).
 
     ```bash
-    $ curl https://downloads.dcos.io/binaries/cli/linux/x86-64/0.4.10/dcos
+    $ curl --remote-name https://downloads.dcos.io/binaries/cli/linux/x86-64/0.4.10/dcos
     ```
     
     **Important:** The CLI must be installed on a system that is external to your DC/OS cluster.


### PR DESCRIPTION
I tried the `curl` command suggested in the docs and the binary was streamed to my console. Better to suggest `curl --remote-name` to the customer so that they can download the binary.