### PR TITLE
Fix jq link text

### DIFF
--- a/1.7/administration/locate-public-agent.md
+++ b/1.7/administration/locate-public-agent.md
@@ -9,7 +9,7 @@ After you have installed DC/OS with a public agent node declared, you can naviga
 
 - DC/OS is installed with at least 1 master and [public agent](/docs/1.7/overview/concepts/#public) node
 - DC/OS [CLI](/docs/1.7/usage/cli/) 0.4.6 or later
-- [jQuery](https://github.com/stedolan/jq/wiki/Installation)
+- [jq](https://github.com/stedolan/jq/wiki/Installation)
 - [SSH](/docs/1.7/administration/sshcluster/) configured
 
 You can find your public agent IP by running this command from the DC/OS CLI. This command SSHs to your cluster to obtain cluster information and then pings [ifconfig.co](https://ifconfig.co/) to determine your public IP address. 

--- a/1.7/usage/tutorials/tomcat/index.md
+++ b/1.7/usage/tutorials/tomcat/index.md
@@ -10,7 +10,7 @@ menu_order: 12
 
 - A DC/OS cluster with at least 1 master and 1 [public agent](/docs/1.7/overview/concepts/#public) node
 - DC/OS [CLI](/docs/1.7/usage/cli/) 0.4.6 or later
-- [jQuery](https://github.com/stedolan/jq/wiki/Installation)
+- [jq](https://github.com/stedolan/jq/wiki/Installation)
 - [SSH](/docs/1.7/administration/sshcluster/) configured
 
 ## Run the container

--- a/1.8/administration/locate-public-agent.md
+++ b/1.8/administration/locate-public-agent.md
@@ -9,7 +9,7 @@ After you have installed DC/OS with a public agent node declared, you can naviga
 
 - DC/OS is installed with at least 1 master and [public agent](/docs/1.8/overview/concepts/#public) node
 - DC/OS [CLI](/docs/1.8/usage/cli/) 0.4.6 or later
-- [jQuery](https://github.com/stedolan/jq/wiki/Installation)
+- [jq](https://github.com/stedolan/jq/wiki/Installation)
 - [SSH](/docs/1.8/administration/sshcluster/) configured
 
 You can find your public agent IP by running this command from the DC/OS CLI. This command SSHs to your cluster to obtain cluster information and then pings [ifconfig.co](https://ifconfig.co/) to determine your public IP address. 


### PR DESCRIPTION
jQuery is sometimes abbreviated as JQ, but the jq we're linking to is something different. See https://stedolan.github.io/jq/.