### PR TITLE
No need to edit Oauth servie file in 1.8

### DIFF
--- a/1.8/administration/installing/custom/configure-proxy.md
+++ b/1.8/administration/installing/custom/configure-proxy.md
@@ -26,14 +26,6 @@ By default the DC/OS [Universe](https://github.com/mesosphere/universe) reposito
     sudo systemctl restart dcos-cosmos
     ```
 
-1.  Edit the unit file `/opt/mesosphere/active/dcos-oauth/dcos.target.wants_master/dcos-oauth.service` to add a line `EnvironmentFile=-/var/lib/dcos/environment.proxy` just after `EnvironmentFile=/opt/mesosphere/environment`.
-
-1.  Do a daemon-reload so that changes in the util file are registered. 
-
-    ```
-    sudo systemctl daemon-reload
-    ```
-
 1.  Restart the Oauth service for the changes to take effect.
 
     ```


### PR DESCRIPTION
There is no need to edit dcos-oauth systemd unit file since the fix is already included in 1.8