### PR TITLE
Ss/storage ui update

### DIFF
--- a/1.8/usage/storage/persistent-volume.md
+++ b/1.8/usage/storage/persistent-volume.md
@@ -77,7 +77,7 @@ For a complete example, see the [Running stateful MySQL on Marathon](#stateful-s
 
 ## Creating a stateful application via the DC/OS Web Interface
 
-1. Create a new service via the web interface in "Services" > "Deploy Service".
+1. Create a new service via the web interface in **Services** > **Deploy Service**.
 1. Click the Volumes tab.
 1. Choose the size of the volume or volumes you will use. Be sure that you choose a volume size that will fit the needs of your application; you will not be able to modify this size after you launch your application.
 1. Specify the container path from which your application will read and write data. The container path must be non-nested and cannot contain slashes e.g. `data`, but not  `../../../etc/opt` or `/user/data/`. If your application requires such a container path, [use this configuration](#nested-paths).

--- a/1.8/usage/storage/persistent-volume.md
+++ b/1.8/usage/storage/persistent-volume.md
@@ -75,7 +75,7 @@ The second volume is a persistent volume with a `containerPath` that matches the
 
 For a complete example, see the [Running stateful MySQL on Marathon](#stateful-sql) section.
 
-## Creating a stateful application via the DC/OS UI
+## Creating a stateful application via the DC/OS Web Interface
 
 1. Create a new service via the web interface in "Services" > "Deploy Service".
 1. Click the Volumes tab.

--- a/1.8/usage/storage/persistent-volume.md
+++ b/1.8/usage/storage/persistent-volume.md
@@ -75,6 +75,14 @@ The second volume is a persistent volume with a `containerPath` that matches the
 
 For a complete example, see the [Running stateful MySQL on Marathon](#stateful-sql) section.
 
+## Creating a stateful application via the DC/OS UI
+
+1. Create a new service via the web interface in "Services" > "Deploy Service".
+1. Click the Volumes tab.
+1. Choose the size of the volume or volumes you will use. Be sure that you choose a volume size that will fit the needs of your application; you will not be able to modify this size after you launch your application.
+1. Specify the container path from which your application will read and write data. The container path must be non-nested and cannot contain slashes e.g. `data`, but not  `../../../etc/opt` or `/user/data/`. If your application requires such a container path, [use this configuration](#nested-paths).
+1. Click Create.
+
 # Scaling stateful applications
 
 When you scale your app down, the volumes associated with the terminated instances are detached but all resources are still reserved. At this point, you may delete the tasks via the Marathon REST API, which will free reserved resources and destroy the persistent volumes.
@@ -139,14 +147,6 @@ However, if another framework does not respect the presence of labels and the se
 The temporary Mesos sandbox is still the target for the `stdout` and `stderr` logs. To view these logs, go to the Marathon pane of the DC/OS web interface.
 
 # Examples
-
-## Creating a stateful application via the DC/OS UI
-
-1. Create a new service via the web interface in "Services" > "Deploy Service".
-1. Click the Volumes tab.
-1. Choose the size of the volume or volumes you will use. Be sure that you choose a volume size that will fit the needs of your application; you will not be able to modify this size after you launch your application.
-1. Specify the container path from which your application will read and write data. The container path must be non-nested and cannot contain slashes e.g. `data`, but not  `../../../etc/opt` or `/user/data/`. If your application requires such a container path, [use this configuration](#nested-paths).
-1. Click Create.
 
 ## Running stateful PostgreSQL on Marathon
 


### PR DESCRIPTION
I noticed the UI instructions were buried in the examples section. Now they're up nearer to the top.
