### PR TITLE
Change CLI install instructions

### DIFF
--- a/1.8/usage/cli/install.md
+++ b/1.8/usage/cli/install.md
@@ -24,35 +24,35 @@ The recommended method to install the DC/OS CLI is by clicking the quick-launch 
 1.  Download the DC/OS CLI binary (`dcos`) to your local directory (for example, `/usr/local/bin/`).
 
     ```bash
-    $ curl -O https://downloads.dcos.io/binaries/cli/linux/x86-64/0.4.10/dcos
+    curl -O https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.8/dcos
     ```
-    
+
     **Important:** The CLI must be installed on a system that is external to your DC/OS cluster.
 
 1.  Make the CLI binary executable.
- 
+
     ```bash
-    chmod +x <path/to/download/directory>/dcos
+    chmod +x dcos
     ```
 
 1.  Point the CLI to your DC/OS master node. In this example, `http://example.com` is the master node IP address.
 
     ```bash
-    dcos config set core.dcos_url http://example.com
+    ./dcos config set core.dcos_url http://example.com
     ```
-    
+
 1.  Authenticate your CLI with your master node and set the auth token:
-   
+
     ```bash
-    $ dcos auth login
+    ./dcos auth login
     ```
-    
+
     Follow the instructions in the DC/OS CLI. For more information about security, see the [documentation](/docs/1.8/administration/id-and-access-mgt/).
-    
+
     Your CLI should now be authenticated with your cluster! Enter `dcos` to get started.
 
     ```bash
-    $ dcos
+    ./dcos
     Command line utility for the Mesosphere Datacenter Operating
     System (DC/OS). The Mesosphere DC/OS is a distributed operating
     system built around Apache Mesos. This utility provides tools
@@ -70,7 +70,7 @@ The recommended method to install the DC/OS CLI is by clicking the quick-launch 
        task           	Manage DC/OS tasks
 
     Get detailed command description with 'dcos <command> --help'.
-    ```    
+    ```
 
 # <a name="osx"></a>Installing on OS X
 
@@ -86,13 +86,13 @@ The recommended method to install the DC/OS CLI is by clicking the quick-launch 
 1.  Download the DC/OS CLI binary (`dcos`) to your local directory (for example, `/usr/local/bin/`).
 
     ```bash
-    $ curl -O https://downloads.dcos.io/binaries/cli/darwin/x86-64/0.4.10/dcos
+    curl -O https://downloads.dcos.io/binaries/cli/darwin/x86-64/dcos-1.8/dcos
     ```
-    
+
     **Important:** The CLI must be installed on a system that is external to your DC/OS cluster.
 
 1.  Make the CLI binary executable.
- 
+
     ```bash
     chmod +x <path/to/download/directory>/dcos
     ```
@@ -104,17 +104,17 @@ The recommended method to install the DC/OS CLI is by clicking the quick-launch 
     ```
 
 1.  Authenticate your CLI with your master node and set the auth token:
-   
+
     ```bash
-    $ dcos auth login
+    dcos auth login
     ```
-    
+
     Follow the instructions in the DC/OS CLI. For more information about security, see the [documentation](/docs/1.8/administration/id-and-access-mgt/).
-    
+
     Your CLI should now be authenticated with your cluster! Enter `dcos` to get started.
-    
+
     ```bash
-    $ dcos
+    dcos
     Command line utility for the Mesosphere Datacenter Operating
     System (DC/OS). The Mesosphere DC/OS is a distributed operating
     system built around Apache Mesos. This utility provides tools
@@ -146,7 +146,7 @@ The recommended method to install the DC/OS CLI is by clicking the quick-launch 
 
 1.  Run command-line environment as Administrator.
 
-1.  Download the DC/OS CLI executable to your local directory ([dcos.exe](https://downloads.dcos.io/binaries/cli/windows/x86-64/0.4.10/dcos.exe)).
+1.  Download the DC/OS CLI executable to your local directory ([dcos.exe](https://downloads.dcos.io/binaries/cli/windows/x86-64/dcos-1.8/dcos.exe)).
 
 1.  Point the CLI to your DC/OS master node. In this example, `http://example.com` is the master node IP address.
 
@@ -157,7 +157,7 @@ The recommended method to install the DC/OS CLI is by clicking the quick-launch 
 1.  Authenticate your CLI with your master node:
 
     ```powershell
-    $ dcos auth login
+    dcos auth login
     ```
 
     Follow the instructions in the DC/OS CLI. For more information about security, see the [documentation](/docs/1.8/administration/id-and-access-mgt/).
@@ -165,7 +165,7 @@ The recommended method to install the DC/OS CLI is by clicking the quick-launch 
     Your CLI should now be authenticated with your cluster!
 
     ```powershell
-    $ dcos
+    dcos
     Command line utility for the Mesosphere Datacenter Operating
     System (DC/OS). The Mesosphere DC/OS is a distributed operating
     system built around Apache Mesos. This utility provides tools


### PR DESCRIPTION
Changes:
1. Changed the URL for the binary to be pinged to the dcos release version.
2. Remove `$` from the examples so that the user can copy and paste them.
3. Minor removal of empty white spaces.
