### PR TITLE
incorrect command for installing as public agent

### DIFF
--- a/1.8/administration/installing/custom/convert-agent-type.md
+++ b/1.8/administration/installing/custom/convert-agent-type.md
@@ -91,7 +91,7 @@ Copy the archived DC/OS installer file (`dcos-install.tar`) to the node that tha
     Public agent nodes:
     
     ```bash
-    $ dcos node --json | jq --raw-output '.[] | select(.reserved_resources.slave_public != null) | .id' | wc -l
+    $ sudo bash /opt/dcos_install_tmp/dcos_install.sh slave_public
     ```
 
  [1]: /docs/1.8/administration/installing/custom/gui/


### PR DESCRIPTION
Corrected the documentation regarding changing the agent node type to a public agent. The command listed was how to see which nodes are public in the DCOS cli, not the bash command for running the install as a public node