### PR TITLE
Update 1.8 proxy config docs to use new path

### DIFF
--- a/1.8/administration/installing/custom/configure-proxy.md
+++ b/1.8/administration/installing/custom/configure-proxy.md
@@ -8,7 +8,7 @@ By default the DC/OS [Universe](https://github.com/mesosphere/universe) reposito
 
 ## Configure DC/OS Master node
 
-1.  Create `/var/lib/dcos/` directory if it doesn't exist and add the following variables in the file `/var/lib/dcos/environment.proxy`:
+1.  Create `/opt/mesosphere/etc` directory if it doesn't exist and add the following variables in the file `/opt/mesosphere/etc/proxy.env`:
 
     ```
     http_proxy=http://user:pass@host:port


### PR DESCRIPTION
In dc/os 1.8 proxy configuration for cosmos was changed to use
`/opt/mesosphere/etc/proxy.env` instead of `/var/lib/dcos/environment.proxy`.
The docs around how to configure proxy support for cosmos are updated to the
new path.