### PR TITLE
Remove python requirement for bootstrap node

### DIFF
--- a/1.8/administration/installing/custom/system-requirements/index.md
+++ b/1.8/administration/installing/custom/system-requirements/index.md
@@ -11,7 +11,6 @@ You must have a single bootstrap node, Mesos master nodes, and Mesos agent nodes
 
 1 node with 2 Cores, 16 GB RAM, 60 GB HDD. This is the node where DC/OS installation is run. This bootstrap node must also have:
 
-*   Python, pip, and virtualenv must be installed for the DC/OS [CLI][1]. pip must be configured to pull packages from PyPI or your private PyPI, if applicable.
 *   A High-availability (HA) TCP/Layer 3 load balancer, such as HAProxy, to balance the following TCP ports to all master nodes: 80, 443, 8080, 8181, 2181, 5050.
 *  An unencrypted SSH key that can be used to authenticate with the cluster nodes over SSH. Encrypted SSH keys are not supported.
 


### PR DESCRIPTION
The DC/OS CLI is a binary now and doesn't need it
dcos_generate_config.sh is a self extracting docker containing a python interpreter.

cc: @joel-hamill @tamarrow 