### PR TITLE
Cassandra typo fix

### DIFF
--- a/1.8/usage/tutorials/cassandra/index.md
+++ b/1.8/usage/tutorials/cassandra/index.md
@@ -144,13 +144,13 @@ core@ip-10-0-6-153 ~ $
 You are now inside your DC/OS cluster and can connect to the Cassandra cluster directly. Connect to the cluster using the cqlsh client:
 
 ```bash
-core@ip-10-0-6-153 ~ $ docker run cassandra:2.2.5 cqlsh <HOST>
+core@ip-10-0-6-153 ~ $ docker run -ti cassandra:3.0.7 cqlsh --cqlversion="3.4.0" <HOST>
 ```
 
-Replace `<HOST>` with the actual host, which that we retrieved by running `dcos cassandra connection`, above:
+Replace `<HOST>` with the actual host, which we retrieved by running `dcos cassandra connection`, above:
 
 ```bash
-core@ip-10-0-6-153 ~ $ docker run -ti cassandra:2.2.5 cqlsh 10.0.2.66
+core@ip-10-0-6-153 ~ $ docker run -ti cassandra:3.0.7 cqlsh --cqlversion="3.4.0" 10.0.2.66
 cqlsh>
 ```
 

--- a/1.9/usage/tutorials/cassandra/index.md
+++ b/1.9/usage/tutorials/cassandra/index.md
@@ -35,7 +35,7 @@ In this tutorial you will learn how to:
 ## Prerequisites
 
 - A running DC/OS cluster with three nodes, each with 2 CPUs and 2 GB of RAM available.
-- [DC/OS CLI](/docs/1.9/usage/cli/install/) installed.
+- [DC/OS CLI](/docs/1.8/usage/cli/install/) installed.
 
 ## Installing Cassandra
 
@@ -144,13 +144,13 @@ core@ip-10-0-6-153 ~ $
 You are now inside your DC/OS cluster and can connect to the Cassandra cluster directly. Connect to the cluster using the cqlsh client:
 
 ```bash
-core@ip-10-0-6-153 ~ $ docker run cassandra:2.2.5 cqlsh <HOST>
+core@ip-10-0-6-153 ~ $ docker run -ti cassandra:3.0.7 cqlsh --cqlversion="3.4.0" <HOST>
 ```
 
-Replace `<HOST>` with the actual host, which that we retrieved by running `dcos cassandra connection`, above:
+Replace `<HOST>` with the actual host, which we retrieved by running `dcos cassandra connection`, above:
 
 ```bash
-core@ip-10-0-6-153 ~ $ docker run -ti cassandra:2.2.5 cqlsh 10.0.2.66
+core@ip-10-0-6-153 ~ $ docker run -ti cassandra:3.0.7 cqlsh --cqlversion="3.4.0" 10.0.2.66
 cqlsh>
 ```
 
@@ -200,7 +200,7 @@ cqlsh> SELECT * FROM demo.map;
 $ dcos package uninstall cassandra
 ```
 
-Use the [framework cleaner](/docs/1.9/usage/managing-services/uninstall/#framework-cleaner) script to remove your Cassandra instance from Zookeeper and to destroy all data associated with it. The script requires several arguments, the values for which are derived from your service name:
+Use the [framework cleaner](/docs/1.8/usage/managing-services/uninstall/#framework-cleaner) script to remove your Cassandra instance from Zookeeper and to destroy all data associated with it. The script requires several arguments, the values for which are derived from your service name:
 
 `framework-role` is `cassandra-role`
 `framework-principal` is `cassandra-principal`

--- a/1.9/usage/tutorials/cassandra/index.md
+++ b/1.9/usage/tutorials/cassandra/index.md
@@ -35,7 +35,7 @@ In this tutorial you will learn how to:
 ## Prerequisites
 
 - A running DC/OS cluster with three nodes, each with 2 CPUs and 2 GB of RAM available.
-- [DC/OS CLI](/docs/1.8/usage/cli/install/) installed.
+- [DC/OS CLI](/docs/1.9/usage/cli/install/) installed.
 
 ## Installing Cassandra
 


### PR DESCRIPTION
## What are your changes?
## What type of changes does your doc introduce?
- [X] Bug fix
- [ ] New feature 
## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [X] Medium
## I have completed these items:
- [X] I have tested all commands and code snippets.
- [X] I have built locally and tested for broken links and formatting.
- [X] I have made this change for all affected versions (e.g. 1.7, 1.8, and 1.9).
- [X] My doc follows the style guide: https://github.com/dcos/dcos-docs#contributing.

Ping @emanic @sascala @joel-hamill for reviewing pull request changes.
## If you included a comment with your commit, it appears here:

Quick typo fix to the Cassandra tutorial. I didn't update the 1.7 docs because I'm not sure what exactly the command should be. I'm investigating, but wanted to get the correct command up at least for the two most current versions.
