### PR TITLE
Added info for binary CLI in 1.7

### DIFF
--- a/1.7/administration/installing/custom/system-requirements/index.md
+++ b/1.7/administration/installing/custom/system-requirements/index.md
@@ -2,7 +2,7 @@
 post_title: System Requirements
 menu_order: 000
 ---
-<!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
+
 
 # Hardware Prerequisites
 

--- a/1.7/usage/cli/command-reference.md
+++ b/1.7/usage/cli/command-reference.md
@@ -3,7 +3,7 @@ post_title: CLI Command Reference
 nav_title: Reference
 menu_order: 5
 ---
-<!-- This source repo for this topic is https://github.com/dcos/dcos-docs -->
+
 
 ## <a name="dcos"></a>dcos
 

--- a/1.7/usage/cli/index.md
+++ b/1.7/usage/cli/index.md
@@ -4,6 +4,8 @@ nav_title: CLI
 menu_order: 10
 ---
 
+**Important:** DC/OS 1.8 introduces binary CLIs for Linux, Windows, and Mac. The install script is replaced with a simple binary CLI. The 1.8 CLI is compatible with DC/OS 1.6.1 forward. For more information, see the [documentation](/1.8/usage/cli/install/).
+
 You can use the DC/OS command-line interface (CLI) to manage your cluster nodes, install DC/OS packages, inspect the cluster state, and administer the DC/OS service subcommands. You can install the CLI from the DC/OS web interface.
 
 To list available commands, either run `dcos` with no parameters or run `dcos help`:

--- a/1.7/usage/cli/install.md
+++ b/1.7/usage/cli/install.md
@@ -4,6 +4,8 @@ nav_title: Installing
 menu_order: 1
 ---
 
+**Important:** DC/OS 1.8 introduces binary CLIs for Linux, Windows, and Mac. The install script is replaced with a simple binary CLI. The 1.8 CLI is compatible with DC/OS 1.6.1 forward. For more information, see the [documentation](/1.8/usage/cli/install/).
+
 *   [Installing the DC/OS CLI on Unix, Linux, and OS X][1]
 *   [Installing the DC/OS CLI on Windows][2]
 


### PR DESCRIPTION
## What are your changes?
- Added pointer from 1.7 docs to 1.8 binary CLI. 
- Removed unnecessary comment.

## What type of changes does your doc introduce?
- [ ] Bug fix
- [ x] New feature 

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [ x] Medium

## I have completed these items:
- [ ] I have tested all commands and code snippets.
- [ ] I have built locally and tested for broken links and formatting.
- [ x] I have made this change for all affected versions (e.g. 1.7, 1.8, and 1.9).
- [ ] My doc follows the style guide: https://github.com/dcos/dcos-docs#contributing.

Ping @emanic @sascala @joel-hamill for reviewing pull request changes.


## If you included a comment with your commit, it appears here:
