### PR TITLE
Updated HAProxy doc

### DIFF
--- a/1.8/administration/haproxy-adminrouter.md
+++ b/1.8/administration/haproxy-adminrouter.md
@@ -98,6 +98,7 @@ These instructions provide a tested [HAProxy](http://www.haproxy.org/) configura
       # Option 2: use TLS-encrypted communication with DC/OS Admin Router, but do
       # not perform server certificate verification (warning: this is insecure, and
       # we hope that you know what you are doing).
+      # server dcos-1 1.2.3.4:443 ssl verify none
       # Rewrite response Location header if it contains an absolute URL
       # pointing to the 'dcoshost' host: replace 'dcoshost' with original
       # request Host header (containing hostname and port).

--- a/1.8/administration/haproxy-adminrouter.md
+++ b/1.8/administration/haproxy-adminrouter.md
@@ -95,13 +95,9 @@ These instructions provide a tested [HAProxy](http://www.haproxy.org/) configura
     
       server dcos-1 1.2.3.4:443 ssl verify required ca-file dcos-ca.crt verifyhost frontend-xxx.eu-central-1.elb.amazonaws.com
     
-      # Variant 2: use TLS-encrypted communication with DC/OS Admin Router, but do
+      # Option 2: use TLS-encrypted communication with DC/OS Admin Router, but do
       # not perform server certificate verification (warning: this is insecure, and
       # we hope that you know what you are doing).
-    
-      # server dcos-1 1.2.3.4:443 ssl verify none
-      server dcos-1 52.57.1.99:443 check-ssl ssl verify required ca-file dcos-ca.crt verifyhost frontend-ElasticL-JW6HOE0W6MAT-1017800469.eu-central-1.elb.amazonaws.com
-    
       # Rewrite response Location header if it contains an absolute URL
       # pointing to the 'dcoshost' host: replace 'dcoshost' with original
       # request Host header (containing hostname and port).

--- a/1.8/administration/securing-your-cluster.md
+++ b/1.8/administration/securing-your-cluster.md
@@ -39,7 +39,7 @@ After you have a valid TLS certificate, install the certificate on each master.
 Copy the certificate and private key to a well known location, such as under
 `/etc/ssl/certs`. 
 
-It's recommended that you run HAProxy in front of Admin Router. For more information, see the [documentation](/docs/1.8/usage/service-discovery/haproxy-adminrouter/).
+It's recommended that you run HAProxy in front of Admin Router. For more information, see the [documentation](/docs/1.8/administration/haproxy-adminrouter/).
 
 ### Private zone
 

--- a/1.8/administration/securing-your-cluster.md
+++ b/1.8/administration/securing-your-cluster.md
@@ -39,7 +39,7 @@ After you have a valid TLS certificate, install the certificate on each master.
 Copy the certificate and private key to a well known location, such as under
 `/etc/ssl/certs`. 
 
-It's recommended that you run HAProxy in front of Admin Router. For more information, see the [documentation](/docs/1.8/administration/haproxy-adminrouter/).
+If you run HAProxy in front of Admin Router, you should secure the communication between them. For information about securing your communication, see the [documentation](/docs/1.8/administration/haproxy-adminrouter/).
 
 ### Private zone
 

--- a/1.9/administration/haproxy-adminrouter.md
+++ b/1.9/administration/haproxy-adminrouter.md
@@ -95,13 +95,9 @@ These instructions provide a tested [HAProxy](http://www.haproxy.org/) configura
     
       server dcos-1 1.2.3.4:443 ssl verify required ca-file dcos-ca.crt verifyhost frontend-xxx.eu-central-1.elb.amazonaws.com
     
-      # Variant 2: use TLS-encrypted communication with DC/OS Admin Router, but do
+      # Option 2: use TLS-encrypted communication with DC/OS Admin Router, but do
       # not perform server certificate verification (warning: this is insecure, and
       # we hope that you know what you are doing).
-    
-      # server dcos-1 1.2.3.4:443 ssl verify none
-      server dcos-1 52.57.1.99:443 check-ssl ssl verify required ca-file dcos-ca.crt verifyhost frontend-ElasticL-JW6HOE0W6MAT-1017800469.eu-central-1.elb.amazonaws.com
-    
       # Rewrite response Location header if it contains an absolute URL
       # pointing to the 'dcoshost' host: replace 'dcoshost' with original
       # request Host header (containing hostname and port).

--- a/1.9/administration/securing-your-cluster.md
+++ b/1.9/administration/securing-your-cluster.md
@@ -39,7 +39,7 @@ After you have a valid TLS certificate, install the certificate on each master.
 Copy the certificate and private key to a well known location, such as under
 `/etc/ssl/certs`. 
 
-It's recommended that you run HAProxy in front of Admin Router. For more information, see the [documentation](/docs/1.8/administration/haproxy-adminrouter/).
+It's recommended that you run HAProxy in front of Admin Router. For more information, see the [documentation](/docs/1.9/administration/haproxy-adminrouter/).
 
 ### Private zone
 
@@ -64,7 +64,7 @@ CloudFormation templates, a large number of ports are exposed to the Internet
 for the public zone. In production systems, it is unlikely that you would
 expose all of these ports. It's recommended that you close all ports except
 80 and 443 (for HTTP/HTTPS traffic) and use
-[Marathon-LB](/docs/1.8/usage/service-discovery/marathon-lb/) with HTTPS for
+[Marathon-LB](/docs/1.9/usage/service-discovery/marathon-lb/) with HTTPS for
 managing ingress traffic.
 
 ### Typical AWS deployment
@@ -89,4 +89,4 @@ Authenticated users are authorized to perform arbitrary actions in their
 cluster. That is, there is currently no fine-grained access control in DC/OS
 besides having access or not having access to services.
 
-See the [Security Administrator's Guide](/docs/1.8/administration/id-and-access-mgt/) for more information.
+See the [Security Administrator's Guide](/docs/1.9/administration/id-and-access-mgt/) for more information.

--- a/1.9/administration/securing-your-cluster.md
+++ b/1.9/administration/securing-your-cluster.md
@@ -39,7 +39,7 @@ After you have a valid TLS certificate, install the certificate on each master.
 Copy the certificate and private key to a well known location, such as under
 `/etc/ssl/certs`. 
 
-It's recommended that you run HAProxy in front of Admin Router. For more information, see the [documentation](/docs/1.9/administration/haproxy-adminrouter/).
+If you run HAProxy in front of Admin Router, you should secure the communication between them. For information about securing your communication, see the [documentation](/docs/1.9/administration/haproxy-adminrouter/).
 
 ### Private zone
 

--- a/1.9/administration/securing-your-cluster.md
+++ b/1.9/administration/securing-your-cluster.md
@@ -35,37 +35,11 @@ By default, Admin Router will permit unencrypted HTTP traffic. This is not
 considered secure, and you must provide a valid TLS certificate and redirect
 all HTTP traffic to HTTPS in order to properly secure access to your cluster.
 
-Once you have a valid TLS certificate, install the certificate on each master.
+After you have a valid TLS certificate, install the certificate on each master.
 Copy the certificate and private key to a well known location, such as under
-`/etc/ssl/certs`. It's suggested that you change the permissions of the
-private key to not be world-readable. Edit the Admin Router `nginx.conf`, by
-opening the file located at
-`/opt/mesosphere/active/adminrouter/nginx/conf`. Modify the nginx
-configuration `server` section, to look like this:
+`/etc/ssl/certs`. 
 
-```
-  server {
-    listen 80 default_server;
-    server_name _;
-    return 301 https://$host$request_uri;
-  }
-
-  server {
-      listen 443 ssl spdy default_server;
-      ssl_certificate /etc/ssl/certs/your-cert.crt;
-      ssl_certificate_key /etc/ssl/certs/your-key.key;
-
-      # rest of config intentionally omitted
-```
-
-In the block above, we're adding a new `server` section above the existing one
-which will redirect all HTTP traffic to HTTPS. We've also removed the
-`listen 80 ...` directive from the second server section. After making the
-changes, restart Admin Router:
-
-```console
-# systemctl restart dcos-adminrouter
-```
+It's recommended that you run HAProxy in front of Admin Router. For more information, see the [documentation](/docs/1.8/administration/haproxy-adminrouter/).
 
 ### Private zone
 
@@ -90,7 +64,7 @@ CloudFormation templates, a large number of ports are exposed to the Internet
 for the public zone. In production systems, it is unlikely that you would
 expose all of these ports. It's recommended that you close all ports except
 80 and 443 (for HTTP/HTTPS traffic) and use
-[Marathon-LB](/docs/1.9/usage/service-discovery/marathon-lb/) with HTTPS for
+[Marathon-LB](/docs/1.8/usage/service-discovery/marathon-lb/) with HTTPS for
 managing ingress traffic.
 
 ### Typical AWS deployment
@@ -115,4 +89,4 @@ Authenticated users are authorized to perform arbitrary actions in their
 cluster. That is, there is currently no fine-grained access control in DC/OS
 besides having access or not having access to services.
 
-See the [Security Administrator's Guide](/docs/1.9/administration/id-and-access-mgt/) for more information.
+See the [Security Administrator's Guide](/docs/1.8/administration/id-and-access-mgt/) for more information.


### PR DESCRIPTION
## What are your changes?

Removed `server dcos-1 52.57.1.99:443 check-ssl` from example.
## What type of changes does your doc introduce?
- [ x] Bug fix
- [ ] New feature 
## What is the urgency level of this change?
- [ ] Blocker
- [ x] High
- [ ] Medium
## I have completed these items:
- [ ] I have tested all commands and code snippets.
- [ ] I have built locally and tested for broken links and formatting.
- [ x] I have made this change for all affected versions (e.g. 1.7, 1.8, and 1.9).
- [x ] My doc follows the style guide: https://github.com/dcos/dcos-docs#contributing.

Ping @emanic @sascala @joel-hamill for reviewing pull request changes.
## If you included a comment with your commit, it appears here:
