### PR TITLE
Removed public from bootstrap IP desc

### DIFF
--- a/1.7/administration/installing/custom/advanced.md
+++ b/1.7/administration/installing/custom/advanced.md
@@ -42,7 +42,7 @@ The DC/OS installation creates these folders:
 
     ```yaml
     ---
-    bootstrap_url: http://<bootstrap_public_ip>:<your_port>
+    bootstrap_url: http://<bootstrap_ip>:<your_port>
     cluster_name: '<cluster-name>'
     exhibitor_storage_backend: static
     ip_detect_filename: /genconf/ip-detect

--- a/1.9/administration/installing/custom/advanced.md
+++ b/1.9/administration/installing/custom/advanced.md
@@ -67,7 +67,7 @@ The DC/OS installation creates these folders:
 
     ```yaml
     ---
-    bootstrap_url: http://<bootstrap_public_ip>:<your_port>
+    bootstrap_url: http://<bootstrap_ip>:<your_port>
     cluster_name: '<cluster-name>'
     exhibitor_storage_backend: static
     ip_detect_filename: /genconf/ip-detect


### PR DESCRIPTION
## What are your changes?

Removed public from bootstrap IP desc
## What type of changes does your doc introduce?
- [ x] Bug fix
- [ ] New feature 
## What is the urgency level of this change?
- [ ] Blocker
- [ x] High
- [ ] Medium
## I have completed these items:
- [ n/a] I have tested all commands and code snippets.
- [ n/a] I have built locally and tested for broken links and formatting.
- [ x] I have made this change for all affected versions (e.g. 1.7, 1.8, and 1.9).
- [ ] My doc follows the style guide: https://github.com/dcos/dcos-docs#contributing.

Ping @emanic @sascala @joel-hamill for reviewing pull request changes.
## If you included a comment with your commit, it appears here:
