### PR TITLE
Fix formatting HAProxy doc

### DIFF
--- a/1.8/administration/haproxy-adminrouter.md
+++ b/1.8/administration/haproxy-adminrouter.md
@@ -10,20 +10,21 @@ The HTTP Proxy must perform on-the-fly HTTP request and response header modifica
 
 These instructions provide a tested [HAProxy](http://www.haproxy.org/) configuration example that handles the named request/response rewriting. This example ensures that the communication between HAProxy and DC/OS Admin Router is TLS-encrypted.
 
-**Tip:**
-
-To avoid having to reconfigure DC/OS, you can use this DNS entry to find your task IP.
-
-* **Agent IP:** Provides the agent IP address: `<taskname>.<framework_name>.agentip.dcos.<dcos_name>.directory`
-
-Terminology:
-* `taskname`: The name of the task
-* `framework_name`: The name of the framework, if you are unsure, it is likely `marathon`
-* `dcos_name`: The name of your DC/OS, which defaults to `thisdcos`
-
 1.  Install HAProxy [1.6.9](http://www.haproxy.org/#down).
 
 1.  Create an HAProxy configuration for DC/OS. This example is for a DC/OS cluster on AWS. For more information on HAProxy configuration parameters, see the [documentation](https://cbonte.github.io/haproxy-dconv/configuration-1.6.html#3).
+
+    **Tip:** You can find your task IP by using the agent IP address DNS entry.
+    
+    ```
+    <taskname>.<framework_name>.agentip.dcos.<dcos_name>.directory
+    ```
+    
+    Where:
+    
+    * `taskname`: The name of the task
+    * `framework_name`: The name of the framework, if you are unsure, it is likely `marathon`
+    * `dcos_name`: The name of your DC/OS, which defaults to `thisdcos`
 
     ```
     global

--- a/1.8/administration/haproxy-adminrouter.md
+++ b/1.8/administration/haproxy-adminrouter.md
@@ -22,9 +22,9 @@ These instructions provide a tested [HAProxy](http://www.haproxy.org/) configura
     
     Where:
     
-    * `taskname`: The name of the task
-    * `framework_name`: The name of the framework, if you are unsure, it is likely `marathon`
-    * `dcos_name`: The name of your DC/OS, which defaults to `thisdcos`
+    * `taskname`: The name of the task.
+    * `framework_name`: The name of the framework, if you are unsure, it is likely `marathon`.
+    * `dcos_name`: The name of your DC/OS, which defaults to `thisdcos`.
 
     ```
     global

--- a/1.9/administration/haproxy-adminrouter.md
+++ b/1.9/administration/haproxy-adminrouter.md
@@ -10,20 +10,21 @@ The HTTP Proxy must perform on-the-fly HTTP request and response header modifica
 
 These instructions provide a tested [HAProxy](http://www.haproxy.org/) configuration example that handles the named request/response rewriting. This example ensures that the communication between HAProxy and DC/OS Admin Router is TLS-encrypted.
 
-**Tip:**
-
-To avoid having to reconfigure DC/OS, you can use this DNS entry to find your task IP.
-
-* **Agent IP:** Provides the agent IP address: `<taskname>.<framework_name>.agentip.dcos.<dcos_name>.directory`
-
-Terminology:
-* `taskname`: The name of the task
-* `framework_name`: The name of the framework, if you are unsure, it is likely `marathon`
-* `dcos_name`: The name of your DC/OS, which defaults to `thisdcos`
-
 1.  Install HAProxy [1.6.9](http://www.haproxy.org/#down).
 
 1.  Create an HAProxy configuration for DC/OS. This example is for a DC/OS cluster on AWS. For more information on HAProxy configuration parameters, see the [documentation](https://cbonte.github.io/haproxy-dconv/configuration-1.6.html#3).
+
+    **Tip:** You can find your task IP by using the agent IP address DNS entry.
+    
+    ```
+    <taskname>.<framework_name>.agentip.dcos.<dcos_name>.directory
+    ```
+    
+    Where:
+    
+    * `taskname`: The name of the task
+    * `framework_name`: The name of the framework, if you are unsure, it is likely `marathon`
+    * `dcos_name`: The name of your DC/OS, which defaults to `thisdcos`
 
     ```
     global

--- a/1.9/administration/haproxy-adminrouter.md
+++ b/1.9/administration/haproxy-adminrouter.md
@@ -22,9 +22,9 @@ These instructions provide a tested [HAProxy](http://www.haproxy.org/) configura
     
     Where:
     
-    * `taskname`: The name of the task
-    * `framework_name`: The name of the framework, if you are unsure, it is likely `marathon`
-    * `dcos_name`: The name of your DC/OS, which defaults to `thisdcos`
+    * `taskname`: The name of the task.
+    * `framework_name`: The name of the framework, if you are unsure, it is likely `marathon`.
+    * `dcos_name`: The name of your DC/OS, which defaults to `thisdcos`.
 
     ```
     global


### PR DESCRIPTION
## What are your changes?
- Moved the agent IP note inline with example.
- Fixed formatting of bullets.
## What type of changes does your doc introduce?
- [x] Bug fix
- [ ] New feature 

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [x] Medium

## I have completed these items:
- [x] I have tested all commands and code snippets.
- [x] I have built locally and tested for broken links and formatting.
- [x] I have made this change for all affected versions (e.g. 1.7, 1.8, and 1.9).
- [ ] My doc follows the style guide: https://github.com/dcos/dcos-docs#contributing.

Ping `@emanic`, `@sascala`, or `@joel-hamill` for reviewing pull request changes.


## If you included a comment with your commit, it appears here: