### PR TITLE
service-discovery: `thisdcos` is not yet configurable

### DIFF
--- a/1.8/administration/haproxy-adminrouter.md
+++ b/1.8/administration/haproxy-adminrouter.md
@@ -17,14 +17,13 @@ These instructions provide a tested [HAProxy](http://www.haproxy.org/) configura
     **Tip:** You can find your task IP by using the agent IP address DNS entry.
     
     ```
-    <taskname>.<framework_name>.agentip.dcos.<dcos_name>.directory
+    <taskname>.<framework_name>.agentip.dcos.thisdcos.directory
     ```
     
     Where:
     
     * `taskname`: The name of the task.
     * `framework_name`: The name of the framework, if you are unsure, it is likely `marathon`.
-    * `dcos_name`: The name of your DC/OS, which defaults to `thisdcos`.
 
     ```
     global

--- a/1.8/administration/overlay-networks/index.md
+++ b/1.8/administration/overlay-networks/index.md
@@ -43,13 +43,12 @@ The components of the overlay network interact in the following ways:
 The [Virtual Network Service](/docs/1.8/overview/components/)
 maps names to IPs on your overlay network. You can use these DNS addresses to access your task:
 
-* **Container IP:** Provides the container IP address: `<taskname>.<framework_name>.containerip.dcos.<dcos_name>.directory`
-* **Auto IP:** Provides a best guess of a task's IP address: `<taskname>.<framework_name>.autoip.dcos.<dcos_name>.directory`. This is used during migrations to the overlay.
+* **Container IP:** Provides the container IP address: `<taskname>.<framework_name>.containerip.dcos.thisdcos.directory`
+* **Auto IP:** Provides a best guess of a task's IP address: `<taskname>.<framework_name>.autoip.dcos.thisdcos.directory`. This is used during migrations to the overlay.
 
 Terminology:
 * `taskname`: The name of the task
 * `framework_name`: The name of the framework, if you are unsure, it is likely `marathon`
-* `dcos_name`: The name of your DC/OS, which defaults to `thisdcos`
 
 # Limitations
 * The DC/OS overlay network does not allow services to reserve IP addresses that result in ephemeral addresses for containers across multiple incarnations on the overlay network. This restriction ensures that a given client connects to the correct service.

--- a/1.9/administration/haproxy-adminrouter.md
+++ b/1.9/administration/haproxy-adminrouter.md
@@ -17,14 +17,13 @@ These instructions provide a tested [HAProxy](http://www.haproxy.org/) configura
     **Tip:** You can find your task IP by using the agent IP address DNS entry.
     
     ```
-    <taskname>.<framework_name>.agentip.dcos.<dcos_name>.directory
+    <taskname>.<framework_name>.agentip.dcos.thisdcos.directory
     ```
     
     Where:
     
     * `taskname`: The name of the task.
     * `framework_name`: The name of the framework, if you are unsure, it is likely `marathon`.
-    * `dcos_name`: The name of your DC/OS, which defaults to `thisdcos`.
 
     ```
     global

--- a/1.9/administration/overlay-networks/index.md
+++ b/1.9/administration/overlay-networks/index.md
@@ -43,13 +43,12 @@ The components of the overlay network interact in the following ways:
 The [Virtual Network Service](/docs/1.9/overview/components/)
 maps names to IPs on your overlay network. You can use these DNS addresses to access your task:
 
-* **Container IP:** Provides the container IP address: `<taskname>.<framework_name>.containerip.dcos.<dcos_name>.directory`
-* **Auto IP:** Provides a best guess of a task's IP address: `<taskname>.<framework_name>.autoip.dcos.<dcos_name>.directory`. This is used during migrations to the overlay.
+* **Container IP:** Provides the container IP address: `<taskname>.<framework_name>.containerip.dcos.thisdcos.directory`
+* **Auto IP:** Provides a best guess of a task's IP address: `<taskname>.<framework_name>.autoip.dcos.thisdcos.directory`. This is used during migrations to the overlay.
 
 Terminology:
 * `taskname`: The name of the task
 * `framework_name`: The name of the framework, if you are unsure, it is likely `marathon`
-* `dcos_name`: The name of your DC/OS, which defaults to `thisdcos`
 
 # Limitations
 * The DC/OS overlay network does not allow services to reserve IP addresses that result in ephemeral addresses for containers across multiple incarnations on the overlay network. This restriction ensures that a given client connects to the correct service.


### PR DESCRIPTION
## What are your changes?

## What type of changes does your doc introduce?
- [x] Bug fix
- [ ] New feature 

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [x] Medium

## I have completed these items:
- [x] I have tested all commands and code snippets.
- [ ] I have built locally and tested for broken links and formatting.
- [x] I have made this change for all affected versions (e.g. 1.7, 1.8, and 1.9).
- [x] My doc follows the style guide: https://github.com/dcos/dcos-docs#contributing.

Ping `@emanic`, `@sascala`, or `@joel-hamill` for reviewing pull request changes.


## If you included a comment with your commit, it appears here:
