### PR TITLE
Fixed ports for masters and agent, and corrected service name

### DIFF
--- a/1.8/administration/monitoring/index.md
+++ b/1.8/administration/monitoring/index.md
@@ -31,10 +31,10 @@ The system health API has four possible states: 0 - 3, OK; CRITICAL; WARNING; UN
 
 ## System health HTTP API endpoint
 
-The system health endpoint is exposed at port 1050:
+The system health endpoint is exposed on port `1050` for masters, and on port `61001` for the agents:
 
 ```bash
-$ curl <host_ip>:1050/system/health/v1
+$ curl <host_ip>:<port>/system/health/v1
 ```
 
 ## Aggregation
@@ -53,10 +53,10 @@ The DC/OS user interface uses these aggregation endpoints to generate the data y
 
 DC/OS components are the [systemd units](https://www.freedesktop.org/wiki/Software/systemd/) that make up the core of DC/OS. These components are monitored by our internal diagnostics utility (`dcos-diagnostics.service`). This utility scans all the DC/OS units, and then exposes an HTTP API on each host.
 
-You can query this HTTP API for any host in the cluster:
+You can query this HTTP API for any host in the cluster, for master nodes on port `1050` and for agents on port `61001`:
 
 ```bash
-curl <host_ip>:1050/system/health/v1
+curl <host_ip>:<port>/system/health/v1
 ```
 
 For a complete description of the DC/OS components, see the [documentation](/docs/1.8/overview/components/).
@@ -77,4 +77,4 @@ If you experience this behavior it's most likely your Mesos agent service on the
 
 ## Troubleshooting
 
-If you have any problems, you can check if the diagnostics service is running by SSH’ing to the Mesos leading master and checking the systemd status of the `dcos-ddt.service`.
+If you have any problems, you can check if the diagnostics service is running by SSH’ing to the Mesos leading master and checking the systemd status of the `dcos-d3t.service`.

--- a/1.9/administration/monitoring/index.md
+++ b/1.9/administration/monitoring/index.md
@@ -31,10 +31,10 @@ The system health API has four possible states: 0 - 3, OK; CRITICAL; WARNING; UN
 
 ## System health HTTP API endpoint
 
-The system health endpoint is exposed at port 1050:
+The system health endpoint is exposed on port `1050` for masters, and on port `61001` for the agents:
 
 ```bash
-$ curl <host_ip>:1050/system/health/v1
+$ curl <host_ip>:<port>/system/health/v1
 ```
 
 ## Aggregation
@@ -53,10 +53,10 @@ The DC/OS user interface uses these aggregation endpoints to generate the data y
 
 DC/OS components are the [systemd units](https://www.freedesktop.org/wiki/Software/systemd/) that make up the core of DC/OS. These components are monitored by our internal diagnostics utility (`dcos-diagnostics.service`). This utility scans all the DC/OS units, and then exposes an HTTP API on each host.
 
-You can query this HTTP API for any host in the cluster:
+You can query this HTTP API for any host in the cluster, for master nodes on port `1050` and for agents on port `61001`:
 
 ```bash
-curl <host_ip>:1050/system/health/v1
+curl <host_ip>:<port>/system/health/v1
 ```
 
 For a complete description of the DC/OS components, see the [documentation](/docs/1.9/overview/components/).
@@ -77,4 +77,4 @@ If you experience this behavior it's most likely your Mesos agent service on the
 
 ## Troubleshooting
 
-If you have any problems, you can check if the diagnostics service is running by SSH’ing to the Mesos leading master and checking the systemd status of the `dcos-ddt.service`.
+If you have any problems, you can check if the diagnostics service is running by SSH’ing to the Mesos leading master and checking the systemd status of the `dcos-d3t.service`.


### PR DESCRIPTION
## What are your changes?

There were some IMO misleading infos regarding the ports for the d3t services running on the masters and agents. This was outlined at https://dcosjira.atlassian.net/browse/SITE-108

Furthermore, the name of the service `dcos-ddt.service` (1.7) was corrected to `dcos-d3t.service` (>=1.8).

## What type of changes does your doc introduce?
- [x] Bug fix
- [ ] New feature 

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [x] Medium

## I have completed these items:
- [ ] I have tested all commands and code snippets.
- [ ] I have built locally and tested for broken links and formatting.
- [x] I have made this change for all affected versions (e.g. 1.7, 1.8, and 1.9).
- [ ] My doc follows the style guide: https://github.com/dcos/dcos-docs#contributing.

Ping `@emanic`, `@sascala`, or `@joel-hamill` for reviewing pull request changes.


## If you included a comment with your commit, it appears here:
