### PR TITLE
Finding a Public Agent IP - Improve Oneliner Output

### DIFF
--- a/1.8/administration/locate-public-agent.md
+++ b/1.8/administration/locate-public-agent.md
@@ -22,7 +22,7 @@ $ for id in $(dcos node --json | jq --raw-output '.[] | select(.reserved_resourc
 Here is an example where the public IP address is `52.39.29.79`:
 
 ```
-$ for id in $(dcos node --json | jq --raw-output '.[] | select(.reserved_resources.slave_public != null and .attributes.public_ip == "true") | .id'); do dcos node ssh --option StrictHostKeyChecking=no --option LogLevel=quiet --master-proxy --mesos-id=$id "curl -s ifconfig.co" ; done 2>/dev/null
+$ for id in $(dcos node --json | jq --raw-output '.[] | select(.reserved_resources.slave_public != null) | .id'); do dcos node ssh --option StrictHostKeyChecking=no --option LogLevel=quiet --master-proxy --mesos-id=$id "curl -s ifconfig.co" ; done 2>/dev/null
 52.39.29.79
 ```
 

--- a/1.8/administration/locate-public-agent.md
+++ b/1.8/administration/locate-public-agent.md
@@ -22,10 +22,8 @@ $ for id in $(dcos node --json | jq --raw-output '.[] | select(.reserved_resourc
 Here is an example where the public IP address is `52.39.29.79`:
 
 ```
-$ for id in $(dcos node --json | jq --raw-output '.[] | select(.reserved_resources.slave_public != null) | .id'); do dcos node ssh --option StrictHostKeyChecking=no --option LogLevel=quiet --master-proxy --mesos-id=$id "curl -s ifconfig.co" ; done 2>/dev/null
+$ for id in $(dcos node --json | jq --raw-output '.[] | select(.reserved_resources.slave_public != null and .attributes.public_ip == "true") | .id'); do dcos node ssh --option StrictHostKeyChecking=no --option LogLevel=quiet --master-proxy --mesos-id=$id "curl -s ifconfig.co" ; done 2>/dev/null
 52.39.29.79
-52.40.79.170
-52.40.79.170
 ```
 
 


### PR DESCRIPTION
## What are your changes?
Remove the extra + redundant ips from the oneliner output.  [Thanks to Michael Hausenblas for help debugging some redherrings in my cluster while looking at this oneliner.]

## What type of changes does your doc introduce?
- [X] Bug fix
- [ ] New feature 

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [ ] Medium

## I have completed these items:
- [ ] I have tested all commands and code snippets.
- [ ] I have built locally and tested for broken links and formatting.
- [ ] I have made this change for all affected versions (e.g. 1.7, 1.8, and 1.9).
- [ ] My doc follows the style guide: https://github.com/dcos/dcos-docs#contributing.

Ping `@emanic`, `@sascala`, or `@joel-hamill` for reviewing pull request changes.
