### PR TITLE
Remove systemd socket activation directive from ExecStart

### DIFF
--- a/1.7/administration/installing/custom/system-requirements/install-docker-centos.md
+++ b/1.7/administration/installing/custom/system-requirements/install-docker-centos.md
@@ -74,7 +74,7 @@ The following instructions demonstrate how to use Docker with OverlayFS on CentO
     $ sudo mkdir -p /etc/systemd/system/docker.service.d && sudo tee /etc/systemd/system/docker.service.d/override.conf <<- EOF
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/docker daemon --storage-driver=overlay -H fd://
+    ExecStart=/usr/bin/docker daemon --storage-driver=overlay
     EOF
     ```
 


### PR DESCRIPTION
Claims online indicate that socket activation via '-H fd://' has been removed from v1.12

https://github.com/docker/docker/issues/22847#issuecomment-244451234

Indeed, that option causes docker to refuse to start on a current CentOS 7 system.

## What are your changes?

## What type of changes does your doc introduce?
- [ ] Bug fix
- [ ] New feature 

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [ ] Medium

## I have completed these items:
- [ ] I have tested all commands and code snippets.
- [ ] I have built locally and tested for broken links and formatting.
- [ ] I have made this change for all affected versions (e.g. 1.7, 1.8, and 1.9).
- [ ] My doc follows the style guide: https://github.com/dcos/dcos-docs#contributing.

Ping `@emanic`, `@sascala`, or `@joel-hamill` for reviewing pull request changes.


## If you included a comment with your commit, it appears here: