### PR TITLE
Component architecture minor fixes

### DIFF
--- a/1.9/overview/architecture/components.md
+++ b/1.9/overview/architecture/components.md
@@ -19,8 +19,8 @@ DC/OS provides a way to view and operate a large number of individual machine-le
 
 <div data-role="collapsible">
 <h2>Apache Mesos</h2>
-<span>
-<p><strong>Description:</strong> Mesos manages resources and tasks as a distributed systems kernel. Mesos Master exposes scheduler, executor, and operator interfaces to facilitate cluster management. Mesos Agent</strong> manages individual executors, tasks, and resources on each [DC/OS agent node](/docs/1.9/overview/concepts/#dcos-agent-node). Mesos Agent Public is a Mesos Agent configured to run on [DC/OS public agent nodes](/docs/1.9/overview/concepts/#public-agent-node).</p>
+<div>
+<p><strong>Description:</strong> Mesos manages resources and tasks as a distributed systems kernel. Mesos Master exposes scheduler, executor, and operator interfaces to facilitate cluster management. Mesos Agent manages individual executors, tasks, and resources on each <a href="/docs/1.9/overview/concepts/#dcos-agent-node">DC/OS agent node</a>. Mesos Agent Public is a Mesos Agent configured to run on <a href="/docs/1.9/overview/concepts/#public-agent-node">DC/OS public agent nodes</a>.</p>
 <p>
   <strong>System Service(s):</strong>
   <ul>
@@ -29,27 +29,54 @@ DC/OS provides a way to view and operate a large number of individual machine-le
     <li><code class="nowrap">dcos-mesos-slave-public.service</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Docs](http://mesos.apache.org/), [Source](https://github.com/apache/mesos)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="http://mesos.apache.org/">Documentation</a></li>
+    <li><a href="https://github.com/apache/mesos">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
-<h2>Exhibitor and Apache Zookeeper</h2>
-<span>
-<p><strong>Description:</strong> Zookeeper stores cluster state. Exhibitor manages Zookeeper and provides a management web interface.<p>
+<h2>Apache Zookeeper</h2>
+<div>
+<p><strong>Description:</strong> Zookeeper provides consistent, highly available, distributed key-value storage for configuration, synchronization, name registration, and cluster state storage.</p>
+<p><strong>System Service(s):</strong> N/A - Zookeeper is supervised by Exhibitor.</p>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://zookeeper.apache.org/">Documentation</a></li>
+    <li><a href="https://github.com/apache/zookeeper">Source</a></li>
+  </ul>
+</p>
+</div>
+</div>
+
+<div data-role="collapsible">
+<h2>Exhibitor</h2>
+<div>
+<p><strong>Description:</strong> Exhibitor supervises Zookeeper and provides a management web interface.</p>
 <p>
   <strong>System Service(s):</strong>
   <ul>
     <li><code class="nowrap">dcos-exhibitor.service</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Exhibitor Source](https://github.com/Netflix/exhibitor), [Exhibitor Wrapper Source](https://github.com/mesosphere/exhibitor-dcos), [Zookeeper Docs](https://zookeeper.apache.org/), [Zookeeper Source](https://github.com/apache/mesos)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/soabase/exhibitor/wiki">Documentation</a></li>
+    <li><a href="https://github.com/dcos/exhibitor">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>DC/OS Installer</h2>
-<span>
+<div>
 <p><strong>Description:</strong> The DC/OS Installer (dcos_generate_config.sh) generates install artifacts and installs DC/OS. As part of the install process on each node, the DC/OS Download service downloads the install artifacts from the bootstrap machine and the DC/OS Setup service installs components using PkgPanda.</p>
 <p>
   <strong>System Service(s):</strong>
@@ -58,27 +85,44 @@ DC/OS provides a way to view and operate a large number of individual machine-le
     <li><code class="nowrap">dcos-setup.service</code></li>
   </ul>
 </p>
-
-<p><strong>See Also:</strong> [Docs](/docs/1.9/administration/installing/), [Source](https://github.com/dcos/dcos)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="/docs/1.9/administration/installing/">Documentation</a></li>
+    <li><a href="https://github.com/dcos/dcos">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>DC/OS GUI</h2>
-<span>
+<div>
 <p><strong>Description:</strong> The DC/OS GUI (web interface) is a browser-based system dashboard and control center.</p>
 <p><strong>System Service(s):</strong> N/A - The GUI is served by Admin Router.</p>
-<p><strong>See Also:</strong> [Docs](/docs/1.9/usage/webinterface/), [Source](https://github.com/dcos/dcos-ui)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="/docs/1.9/usage/webinterface/">Documentation</a></li>
+    <li><a href="https://github.com/dcos/dcos-ui">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>DC/OS CLI</h2>
-<span>
+<div>
 <p><strong>Description:</strong> The DC/OS CLI is a terminal-based remote client.</p>
 <p><strong>System Service(s):</strong> N/A - The CLI is a user downloadable binary.</p>
-<p><strong>See Also:</strong> [Docs](/docs/1.9/usage/cli/), [Source](https://github.com/dcos/dcos-cli)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="/docs/1.9/usage/cli/">Documentation</a></li>
+    <li><a href="https://github.com/dcos/dcos-cli">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 
@@ -90,7 +134,7 @@ DC/OS includes built-in orchestration of the most commonly used high level conta
 
 <div data-role="collapsible">
 <h2>Marathon</h2>
-<span>
+<div>
 <p><strong>Description:</strong> Marathon orchestrates long-lived containerized services (apps and pods).</p>
 <p>
   <strong>System Service(s):</strong>
@@ -98,13 +142,19 @@ DC/OS includes built-in orchestration of the most commonly used high level conta
     <li><code class="nowrap">dcos-marathon.service</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Docs](https://mesosphere.github.io/marathon/), [Source](https://github.com/mesosphere/marathon)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://mesosphere.github.io/marathon/">Documentation</a></li>
+    <li><a href="https://github.com/mesosphere/marathon">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>Metronome</h2>
-<span>
+<div>
 <p><strong>Description:</strong> Metronome orchestrates short-lived, scheduled or immediate, containerized jobs.</p>
 <p>
   <strong>System Service(s):</strong>
@@ -112,8 +162,14 @@ DC/OS includes built-in orchestration of the most commonly used high level conta
     <li><code class="nowrap">dcos-metronome.service</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Docs](/docs/1.9/usage/jobs/), [Source](https://github.com/dcos/metronome)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="/docs/1.9/usage/jobs/">Documentation</a></li>
+    <li><a href="https://github.com/dcos/metronome">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 
@@ -124,31 +180,43 @@ Container runtimes execute and manage machine level processes in isolated operat
 DC/OS supports multiple container runtimes using [Mesos' containerizer abstraction](http://mesos.apache.org/documentation/latest/containerizer/).
 
 <div data-role="collapsible">
-<h2>Mesos Container Runtime</h2>
-<span>
-<p><strong>Description:</strong> Mesos Container Runtime (Mesos Containerizer) is a logical component built-in to the Mesos Agent, not technically a separate process. It containerizes Mesos tasks with configurable isolators. Mesos Container Runtime is often called the Mesos Universal Container Runtime because it supports multiple image formats, including Docker images without using Docker Engine.</p>
-<p><strong>System Service(s):</strong> N/A - The runtime is part of Mesos Agent.</p>
-<p><strong>See Also:</strong> [Mesos Containerizer Docs](http://mesos.apache.org/documentation/latest/mesos-containerizer/)</p>
-</span>
+<h2>Universal Container Runtime</h2>
+<div>
+<p><strong>Description:</strong> Universal Container Runtime (Mesos Containerizer) is a logical component built-in to the Mesos Agent, not technically a separate process. It containerizes Mesos tasks with configurable isolators. Universal Container Runtime supports multiple image formats, including Docker images without using Docker Engine.</p>
+<p><strong>System Service(s):</strong> N/A - Universal Container Runtime is part of Mesos Agent.</p>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="http://mesos.apache.org/documentation/latest/mesos-containerizer/">Mesos Containerizer Documentation</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>Docker Engine</h2>
-<span>
+<div>
 <p><strong>Description:</strong> Docker Engine is not installed by the DC/OS Installer, but rather is a system dependency that runs on each node. Mesos Agent also includes a separate logical component called Docker Containerizer which delegates the containerization of Mesos task to Docker Engine.</p>
 <p>
   <strong>System Service(s):</strong>
   <ul>
-    <li><code class="nowrap">docker.service</code></li>
+    <li><code class="nowrap">docker.service</code> - Docker Engine is not installed by the DC/OS installer.</li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Docker Containerizer Docs](http://mesos.apache.org/documentation/latest/docker-containerizer/), [Docker Engine Docs](https://docs.docker.com/engine/), [Docker Engine Source](https://github.com/docker/docker/)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="http://mesos.apache.org/documentation/latest/docker-containerizer/">Docker Containerizer Documentation</a></li>
+    <li><a href="https://docs.docker.com/engine/">Docker Engine Documentation</a></li>
+    <li><a href="https://github.com/docker/docker/">Docker Engine Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>Docker GC</h2>
-<span>
+<div>
 <p><strong><em>NEW IN 1.9.0</em></strong></p>
 <p><strong>Description:</strong> Docker GC periodically garbage collects Docker containers and images.</p>
 <p>
@@ -158,8 +226,13 @@ DC/OS supports multiple container runtimes using [Mesos' containerizer abstracti
     <li><code class="nowrap">dcos-docker-gc.timer</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/spotify/docker-gc)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/spotify/docker-gc">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 
@@ -169,7 +242,7 @@ No software runs perfectly, especially not the first time. Distribute tasks acro
 
 <div data-role="collapsible">
 <h2>DC/OS Diagnostics</h2>
-<span>
+<div>
 <p><strong>Description:</strong> The DC/OS Diagnostics service aggregates and exposes system component health. DC/OS Diagnostics is also known as DC/OS Distributed Diagnostics Tool (3DT).</p>
 <p>
   <strong>System Service(s):</strong>
@@ -178,13 +251,18 @@ No software runs perfectly, especially not the first time. Distribute tasks acro
     <li><code class="nowrap">dcos-3dt.socket</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/dcos/3dt)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/dcos/3dt">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>DC/OS Log</h2>
-<span>
+<div>
 <p><strong><em>NEW IN 1.9.0</em></strong></p>
 <p><strong>Description:</strong> The DC/OS Log service exposes component, container, and task logs.</p>
 <p>
@@ -196,13 +274,18 @@ No software runs perfectly, especially not the first time. Distribute tasks acro
     <li><code class="nowrap">dcos-log-agent.socket</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/dcos/dcos-log)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/dcos/dcos-log">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>Logrotate</h2>
-<span>
+<div>
 <p><strong>Description:</strong> Logrotate manages rotation, compression, and deletion of historical log files.</p>
 <p>
   <strong>System Service(s):</strong>
@@ -213,13 +296,19 @@ No software runs perfectly, especially not the first time. Distribute tasks acro
     <li><code class="nowrap">dcos-logrotate-agent.timer</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Docs](http://www.linuxcommand.org/man_pages/logrotate8.html), [Source](https://github.com/logrotate/logrotate)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="http://www.linuxcommand.org/man_pages/logrotate8.html">Documentation</a></li>
+    <li><a href="https://github.com/logrotate/logrotate">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>DC/OS Metrics</h2>
-<span>
+<div>
 <p><strong><em>NEW IN 1.9.0</em></strong></p>
 <p><strong>Description:</strong> The DC/OS Metrics service exposes host, container, and task metrics.</p>
 <p>
@@ -231,14 +320,19 @@ No software runs perfectly, especially not the first time. Distribute tasks acro
     <li><code class="nowrap">dcos-metrics-agent.socket</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/dcos/dcos-metrics)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/dcos/dcos-metrics">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>DC/OS Signal</h2>
-<span>
-<p><strong>Description:</strong> The DC/OS Signal service reports cluster telemetry and analytics to help improve DC/OS. Administrators can [opt-out of telemetry](/docs/1.9/administration/opt-out/#telemetry) at install time.</p>
+<div>
+<p><strong>Description:</strong> The DC/OS Signal service reports cluster telemetry and analytics to help improve DC/OS. Administrators can <a href="/docs/1.9/administration/installing/opt-out/#telemetry">opt-out of telemetry</a> at install time.</p>
 <p>
   <strong>System Service(s):</strong>
   <ul>
@@ -246,13 +340,18 @@ No software runs perfectly, especially not the first time. Distribute tasks acro
     <li><code class="nowrap">dcos-signal.timer</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/dcos/dcos-signal)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/dcos/dcos-signal">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>DC/OS History</h2>
-<span>
+<div>
 <p><strong>Description:</strong> The DC/OS History service caches and exposes historical system state to facilitate cluster usage statistics in the GUI.</p>
 <p>
   <strong>System Service(s):</strong>
@@ -260,8 +359,13 @@ No software runs perfectly, especially not the first time. Distribute tasks acro
     <li><code class="nowrap">dcos-history.service</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/dcos/dcos/tree/master/packages/dcos-history/extra)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/dcos/dcos/tree/master/packages/dcos-history/extra">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 
@@ -271,8 +375,8 @@ In a world where machines are are given numbers instead of names, tasks are sche
 
 <div data-role="collapsible">
 <h2>Admin Router</h2>
-<span>
-<p><strong>Description:</strong> Admin Router exposes a unified control plane proxy for components and services using [NGINX](https://www.nginx.com/). Admin Router Agent proxies node-specific health, logs, metrics, and package management internal endpoints.</p>
+<div>
+<p><strong>Description:</strong> Admin Router exposes a unified control plane proxy for components and services using <a href="https://www.nginx.com/">NGINX</a>. Admin Router Agent proxies node-specific health, logs, metrics, and package management internal endpoints.</p>
 <p>
   <strong>System Service(s):</strong>
   <ul>
@@ -284,13 +388,18 @@ In a world where machines are are given numbers instead of names, tasks are sche
     <li><code class="nowrap">dcos-adminrouter-agent-reload.timer</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/dcos/adminrouter)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/dcos/adminrouter">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>Mesos DNS</h2>
-<span>
+<div>
 <p><strong>Description:</strong> Mesos DNS provides domain name based service discovery within the cluster.</p>
 <p>
   <strong>System Service(s):</strong>
@@ -298,13 +407,19 @@ In a world where machines are are given numbers instead of names, tasks are sche
     <li><code class="nowrap">dcos-mesos-dns.service</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Docs](http://mesosphere.github.io/mesos-dns/), [Source](https://github.com/mesosphere/mesos-dns)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="http://mesosphere.github.io/mesos-dns/">Documentation</a></li>
+    <li><a href="https://github.com/mesosphere/mesos-dns">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>Spartan</h2>
-<span>
+<div>
 <p><strong>Description:</strong> Spartan forwards DNS requests to multiple DNS servers. Spartan Watchdog restarts Spartan when it is unhealthy.</p>
 <p>
   <strong>System Service(s):</strong>
@@ -314,14 +429,19 @@ In a world where machines are are given numbers instead of names, tasks are sche
     <li><code class="nowrap">dcos-spartan-watchdog.timer</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/dcos/spartan)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/dcos/spartan">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>Generate resolv.conf</h2>
-<span>
-<p><strong>Description:</strong> Generate resolv.conf configures network name resolution ([systemd-resolved](https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html)) by updating <code class="nowrap">/etc/resolv.conf</code> to facilitate DC/OS's software defined networking.</p>
+<div>
+<p><strong>Description:</strong> Generate resolv.conf configures network name resolution (<a href="https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html)">systemd-resolved</a> by updating <code class="nowrap">/etc/resolv.conf</code> to facilitate DC/OS's software defined networking.</p>
 <p>
   <strong>System Service(s):</strong>
   <ul>
@@ -329,41 +449,57 @@ In a world where machines are are given numbers instead of names, tasks are sche
     <li><code class="nowrap">dcos-gen-resolvconf.timer</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/dcos/dcos/blob/master/packages/spartan/extra/gen_resolvconf.py)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/dcos/dcos/blob/master/packages/spartan/extra/gen_resolvconf.py">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>Minuteman</h2>
-<span>
-<p><strong>Description:</strong> Minuteman provides distributed [Layer 4](https://en.wikipedia.org/wiki/Transport_layer) virtual IP load balancing.</p>
+<div>
+<p><strong>Description:</strong> Minuteman provides distributed <a href="https://en.wikipedia.org/wiki/Transport_layer">Layer 4</a> virtual IP load balancing.</p>
 <p>
   <strong>System Service(s):</strong>
   <ul>
     <li><code class="nowrap">dcos-minuteman.service</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Docs](/docs/1.9/usage/service-discovery/load-balancing-vips/), [Source](https://github.com/dcos/minuteman)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="/docs/1.9/usage/service-discovery/load-balancing-vips/">Documentation</a></li>
+    <li><a href="https://github.com/dcos/minuteman">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>Navstar</h2>
-<span>
-<p><strong>Description:</strong> Navstar orchestrates virtual overlay networks using [VXLAN](https://en.wikipedia.org/wiki/Virtual_Extensible_LAN).</p>
+<div>
+<p><strong>Description:</strong> Navstar orchestrates virtual overlay networks using <a href="https://en.wikipedia.org/wiki/Virtual_Extensible_LAN">VXLAN</a>.</p>
 <p>
   <strong>System Service(s):</strong>
   <ul>
     <li><code class="nowrap">dcos-navstar.service</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/dcos/navstar)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/dcos/navstar">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>Erlang Port Mapping Daemon</h2>
-<span>
+<div>
 <p><strong>Description:</strong> Erlang Port Mapping Daemon (EPMD) maps symbolic names to machine addresses, facilitating named virtual IPs.</p>
 <p>
   <strong>System Service(s):</strong>
@@ -371,8 +507,13 @@ In a world where machines are are given numbers instead of names, tasks are sche
     <li><code class="nowrap">dcos-epmd.service</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/erlang/epmd)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/erlang/epmd">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 
@@ -382,21 +523,26 @@ Just as machine operating systems need package management to install, upgrade, c
 
 <div data-role="collapsible">
 <h2>Cosmos</h2>
-<span>
-<p><strong>Description:</strong> Cosmos installs and manages DC/OS packages from [DC/OS package repositories](/docs/1.9/usage/repo/), such as [Mesosphere Universe](https://github.com/mesosphere/universe).</p>
+<div>
+<p><strong>Description:</strong> Cosmos installs and manages DC/OS packages from <a href="/docs/1.9/usage/repo/">DC/OS package repositories</a>, such as <a href="https://github.com/mesosphere/universe">Mesosphere Universe</a>.</p>
 <p>
   <strong>System Service(s):</strong>
   <ul>
     <li><code class="nowrap">dcos-cosmos.service</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/dcos/cosmos)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/dcos/cosmos">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 <div data-role="collapsible">
 <h2>Pkgpanda</h2>
-<span>
+<div>
 <p><strong>Description:</strong> Pkgpanda installs and manages DC/OS components.</p>
 <p>
   <strong>System Service(s):</strong>
@@ -405,8 +551,13 @@ Just as machine operating systems need package management to install, upgrade, c
     <li><code class="nowrap">dcos-pkgpanda-api.socket</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/dcos/dcos/tree/master/pkgpanda)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/dcos/dcos/tree/master/pkgpanda">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 
@@ -416,7 +567,7 @@ Identity management in DC/OS is delegated to external identity providers, taking
 
 <div data-role="collapsible">
 <h2>DC/OS Authentication</h2>
-<span>
+<div>
 <p><strong>Description:</strong> The DC/OS Authentication (OAuth) service authenticates users using [OpenID Connect](http://openid.net/connect/) and [Auth0](https://auth0.com/).</p>
 <p>
   <strong>System Service(s):</strong>
@@ -424,8 +575,13 @@ Identity management in DC/OS is delegated to external identity providers, taking
     <li><code class="nowrap">dcos-oauth.service</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Source](https://github.com/dcos/dcos-oauth)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="https://github.com/dcos/dcos-oauth">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 
@@ -435,7 +591,7 @@ DC/OS provides multiple different ways to provision and allocate disk space and 
 
 <div data-role="collapsible">
 <h2>REX-Ray</h2>
-<span>
+<div>
 <p><strong>Description:</strong> REX-Ray orchestrates provisioning, attachment, and mounting of external persistent volumes.</p>
 <p>
   <strong>System Service(s):</strong>
@@ -443,8 +599,14 @@ DC/OS provides multiple different ways to provision and allocate disk space and 
     <li><code class="nowrap">dcos-rexray.service</code></li>
   </ul>
 </p>
-<p><strong>See Also:</strong> [Docs](http://rexray.readthedocs.io/), [Source](https://github.com/codedellemc/rexray)</p>
-</span>
+<p>
+  <strong>See Also:</strong>
+  <ul>
+    <li><a href="http://rexray.readthedocs.io/">Documentation</a></li>
+    <li><a href="https://github.com/codedellemc/rexray">Source</a></li>
+  </ul>
+</p>
+</div>
 </div>
 
 
@@ -452,7 +614,7 @@ DC/OS provides multiple different ways to provision and allocate disk space and 
 
 The **Cluster ID service** was removed in DC/OS 1.9.0. The universally unique identifier (UUID) for each cluster is now generated by the DC/OS Setup service.
 
-The **Mesos Persistent Volume Discovery service** was removed in DC/OS 1.9.0. Detection of [mounted disk resources](https://dcos.io/docs/1.8/administration/storage/mount-disk-resources/) is now handled by the DC/OS Setup service.
+The **Mesos Persistent Volume Discovery service** was removed in DC/OS 1.9.0. Detection of [mounted disk resources](/docs/1.9/administration/storage/mount-disk-resources/) is now handled by the DC/OS Setup service.
 
 
 # Sockets and Timers

--- a/1.9/overview/architecture/components.md
+++ b/1.9/overview/architecture/components.md
@@ -641,44 +641,57 @@ To see a list of the systemd components running on any particular node, list the
 
 ```
 [vagrant@m1 ~]$ ls /etc/systemd/system/dcos.target.wants/
-dcos-3dt.service                 dcos-log-master.service        dcos-minuteman.service
-dcos-adminrouter-reload.service  dcos-log-master.socket         dcos-navstar.service
-dcos-adminrouter-reload.timer    dcos-logrotate-master.service  dcos-oauth.service
-dcos-adminrouter.service         dcos-logrotate-master.timer    dcos-pkgpanda-api.service
-dcos-cosmos.service              dcos-marathon.service          dcos-pkgpanda-api.socket
-dcos-epmd.service                dcos-mesos-dns.service         dcos-signal.service
-dcos-exhibitor.service           dcos-mesos-master.service      dcos-signal.timer
-dcos-gen-resolvconf.service      dcos-metrics-master.service    dcos-spartan.service
-dcos-gen-resolvconf.timer        dcos-metrics-master.socket     dcos-spartan-watchdog.service
-dcos-history.service             dcos-metronome.service         dcos-spartan-watchdog.timer
+dcos-3dt.service                 dcos-mesos-dns.service
+dcos-adminrouter-reload.service  dcos-mesos-master.service
+dcos-adminrouter-reload.timer    dcos-metrics-master.service
+dcos-adminrouter.service         dcos-metrics-master.socket
+dcos-cosmos.service              dcos-metronome.service
+dcos-epmd.service                dcos-navstar.service
+dcos-exhibitor.service           dcos-oauth.service
+dcos-gen-resolvconf.service      dcos-pkgpanda-api.service
+dcos-gen-resolvconf.timer        dcos-pkgpanda-api.socket
+dcos-history.service             dcos-signal.service
+dcos-log-master.service          dcos-signal.timer
+dcos-log-master.socket           dcos-spartan.service
+dcos-logrotate-master.service    dcos-spartan-watchdog.service
+dcos-logrotate-master.timer      dcos-spartan-watchdog.timer
+dcos-marathon.service
 ```
 
 ## Private Agent Node
 
 ```
 [vagrant@a1 ~]$ ls /etc/systemd/system/dcos.target.wants/
-dcos-3dt.service                       dcos-gen-resolvconf.timer     dcos-navstar.service
-dcos-3dt.socket                        dcos-log-agent.service        dcos-pkgpanda-api.service
-dcos-adminrouter-agent-reload.service  dcos-log-agent.socket         dcos-pkgpanda-api.socket
-dcos-adminrouter-agent-reload.timer    dcos-logrotate-agent.service  dcos-rexray.service
-dcos-adminrouter-agent.service         dcos-logrotate-agent.timer    dcos-signal.timer
-dcos-docker-gc.service                 dcos-mesos-slave.service      dcos-spartan.service
-dcos-docker-gc.timer                   dcos-metrics-agent.service    dcos-spartan-watchdog.service
-dcos-epmd.service                      dcos-metrics-agent.socket     dcos-spartan-watchdog.timer
-dcos-gen-resolvconf.service            dcos-minuteman.service
+dcos-3dt.service                       dcos-logrotate-agent.timer
+dcos-3dt.socket                        dcos-mesos-slave.service
+dcos-adminrouter-agent-reload.service  dcos-metrics-agent.service
+dcos-adminrouter-agent-reload.timer    dcos-metrics-agent.socket
+dcos-adminrouter-agent.service         dcos-navstar.service
+dcos-docker-gc.service                 dcos-pkgpanda-api.service
+dcos-docker-gc.timer                   dcos-pkgpanda-api.socket
+dcos-epmd.service                      dcos-rexray.service
+dcos-gen-resolvconf.service            dcos-signal.timer
+dcos-gen-resolvconf.timer              dcos-spartan.service
+dcos-log-agent.service                 dcos-spartan-watchdog.service
+dcos-log-agent.socket                  dcos-spartan-watchdog.timer
+dcos-logrotate-agent.service
 ```
 
 ## Public Agent Node
 
 ```
 [vagrant@p1 ~]$ ls /etc/systemd/system/dcos.target.wants/
-dcos-3dt.service                       dcos-gen-resolvconf.timer        dcos-navstar.service
-dcos-3dt.socket                        dcos-log-agent.service           dcos-pkgpanda-api.service
-dcos-adminrouter-agent-reload.service  dcos-log-agent.socket            dcos-pkgpanda-api.socket
-dcos-adminrouter-agent-reload.timer    dcos-logrotate-agent.service     dcos-rexray.service
-dcos-adminrouter-agent.service         dcos-logrotate-agent.timer       dcos-signal.timer
-dcos-docker-gc.service                 dcos-mesos-slave-public.service  dcos-spartan.service
-dcos-docker-gc.timer                   dcos-metrics-agent.service       dcos-spartan-watchdog.service
-dcos-epmd.service                      dcos-metrics-agent.socket        dcos-spartan-watchdog.timer
-dcos-gen-resolvconf.service            dcos-minuteman.service
+dcos-3dt.service                       dcos-logrotate-agent.timer
+dcos-3dt.socket                        dcos-mesos-slave-public.service
+dcos-adminrouter-agent-reload.service  dcos-metrics-agent.service
+dcos-adminrouter-agent-reload.timer    dcos-metrics-agent.socket
+dcos-adminrouter-agent.service         dcos-navstar.service
+dcos-docker-gc.service                 dcos-pkgpanda-api.service
+dcos-docker-gc.timer                   dcos-pkgpanda-api.socket
+dcos-epmd.service                      dcos-rexray.service
+dcos-gen-resolvconf.service            dcos-signal.timer
+dcos-gen-resolvconf.timer              dcos-spartan.service
+dcos-log-agent.service                 dcos-spartan-watchdog.service
+dcos-log-agent.socket                  dcos-spartan-watchdog.timer
+dcos-logrotate-agent.service
 ```


### PR DESCRIPTION
## What are your changes?
This PR synchronizes dcos-docs with minor changed made to dcos-docs-enterprise.

- Minor tweaks to component descriptions
- Switch "see also" to use bullets
- Switch systemd service lists to be 2 columns
- Switch to html link format (link rendering wasn't working)
- Fix a 1.8 docs link to be 1.9

## What type of changes does your doc introduce?
- [X] Bug fix
- [ ] New feature 

## What is the urgency level of this change?
- [ ] Blocker
- [X] High
- [ ] Medium

## I have completed these items:
- [X] I have tested all commands and code snippets.
- [X] I have built locally and tested for broken links and formatting.
- [X] I have made this change for all affected versions (e.g. 1.7, 1.8, and 1.9).
- [X] My doc follows the style guide: https://github.com/dcos/dcos-docs#contributing.
