### PR TITLE
Fix feature maturity syntax

### DIFF
--- a/1.8/usage/storage/external-storage.md
+++ b/1.8/usage/storage/external-storage.md
@@ -1,7 +1,7 @@
 ---
 post_title: External Persistent Volumes
 menu_order: 1
-feature-maturity: experimental
+feature_maturity: experimental
 ---
 
 Use external volumes when fault-tolerance is crucial for your app. If a host fails, the native Marathon instance reschedules your app on another host, along with its associated data, without user intervention. External volumes also typically offer a larger amount of storage.

--- a/1.9/usage/storage/external-storage.md
+++ b/1.9/usage/storage/external-storage.md
@@ -1,7 +1,7 @@
 ---
 post_title: External Persistent Volumes
 menu_order: 1
-feature-maturity: experimental
+feature_maturity: experimental
 ---
 
 Use external volumes when fault-tolerance is crucial for your app. If a host fails, the native Marathon instance reschedules your app on another host, along with its associated data, without user intervention. External volumes also typically offer a larger amount of storage.


### PR DESCRIPTION
## What are your changes?
Fix feature maturity syntax for external volumes.

## What type of changes does your doc introduce?
- [x] Bug fix
- [ ] New feature 

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [x] Medium

## I have completed these items:
- [ ] I have tested all commands and code snippets.
- [ ] I have built locally and tested for broken links and formatting.
- [ ] I have made this change for all affected versions (e.g. 1.7, 1.8, and 1.9).
- [ ] My doc follows the style guide: https://github.com/dcos/dcos-docs#contributing.

** Ping a doc team member to review pull request (`@joel-hamill`, `@emanic`, or `@sascala`) **
