### PR TITLE
Fixup proxy docs for DOCS-1710

### DIFF
--- a/1.7/administration/installing/custom/configure-proxy.md
+++ b/1.7/administration/installing/custom/configure-proxy.md
@@ -16,7 +16,7 @@ By default the DC/OS [Universe](https://github.com/mesosphere/universe) reposito
     no_proxy=".mesos,.thisdcos.directory,.dcos.directory,.zk,127.0.0.1,localhost"
     ```
     
-    If you are not sure about the values for `http_proxy` and `https_proxy` variables for your environment, Please contact your system administrator.
+    If you are not sure about the values for `http_proxy` and `https_proxy` variables for your environment, contact your system administrator.
     
     If you have any hosts or domains you would like to bypass the proxy you can add them to the `no_proxy` variable like this: `no_proxy=".mesos,.thisdcos.directory,.dcos.directory,.zk,127.0.0.1,localhost,foo.bar.com,.baz.com"`
     

--- a/1.7/administration/installing/custom/configure-proxy.md
+++ b/1.7/administration/installing/custom/configure-proxy.md
@@ -11,14 +11,14 @@ By default the DC/OS [Universe](https://github.com/mesosphere/universe) reposito
 1.  Create `/var/lib/dcos/` directory if it doesn't exist and add the following variables in the file `/var/lib/dcos/environment.proxy`:
 
     ```
-    http_proxy=http://user:pass@host:port
-    https_proxy=http://user:pass@host:port
-    no_proxy="*.mesos,127.0.0.1,localhost"
+    http_proxy=http://<user>:<pass>@<proxy_host>:<http_proxy_port>
+    https_proxy=https://<user>:<pass>@<proxy_host>:<https_proxy_port>
+    no_proxy=".mesos,.thisdcos.directory,.dcos.directory,.zk,127.0.0.1,localhost"
     ```
     
     If you are not sure about the values for `http_proxy` and `https_proxy` variables for your environment, Please contact your system administrator.
     
-    If you have any hosts or domains you would like to bypass the proxy you can add them to the `no_proxy` variable like this: `no_proxy="*.mesos,127.0.0.1,localhost,localaddress,.localdomain.com"`
+    If you have any hosts or domains you would like to bypass the proxy you can add them to the `no_proxy` variable like this: `no_proxy=".mesos,.thisdcos.directory,.dcos.directory,.zk,127.0.0.1,localhost,foo.bar.com,.baz.com"`
     
 1.  Restart the Cosmos service for the changes to take effect.
 

--- a/1.7/usage/cli/configure.md
+++ b/1.7/usage/cli/configure.md
@@ -49,10 +49,10 @@ To configure a proxy for the CLI:
 
 *   From the CLI terminal, define the environment variables `http_proxy` and `https_proxy`:
     
-        $ export http_proxy=’<http://your/proxy/here/>’
-        $ export https_proxy=’<http://your/proxy/here/>’
+        $ export http_proxy=’http://<user>:<pass>@<proxy_host>:<http_proxy_port>’
+        $ export https_proxy=’https://<user>:<pass>@<proxy_host>:<https_proxy_port>’
         
 
 *   Define `no_proxy` for domains that you don’t want to use the proxy for:
     
-        $ export no_proxy="127.0.0.1, localhost”
+        $ export no_proxy=".mesos,.thisdcos.directory,.dcos.directory,.zk,127.0.0.1,localhost,foo.bar.com,.baz.com”

--- a/1.8/administration/installing/custom/advanced.md
+++ b/1.8/administration/installing/custom/advanced.md
@@ -82,10 +82,11 @@ The DC/OS installation creates these folders:
     - 8.8.4.4
     - 8.8.8.8
     use_proxy: 'true'
-    http_proxy: http://<your_http_proxy>/
-    https_proxy: https://<your_https_proxy>/
+    http_proxy: http://<user>:<pass>@<proxy_host>:<http_proxy_port>
+    https_proxy: https://<user>:<pass>@<proxy_host>:<https_proxy_port>
     no_proxy: 
-    - '*.int.example.com'    
+    - 'foo.bar.com'
+    - '.baz.com'
     ```
 
 2. Create a `ip-detect` script

--- a/1.8/administration/installing/custom/cli.md
+++ b/1.8/administration/installing/custom/cli.md
@@ -165,10 +165,11 @@ The DC/OS installation creates these folders:
     ssh_user: <username>
     # A custom proxy is optional. For details see the config documentation.
     use_proxy: 'true'
-    http_proxy: http://<your_http_proxy>/
-    https_proxy: https://<your_https_proxy>/
+    http_proxy: http://<user>:<pass>@<proxy_host>:<http_proxy_port>
+    https_proxy: https://<user>:<pass>@<proxy_host>:<https_proxy_port>
     no_proxy: 
-    - '*.int.example.com' 
+    - 'foo.bar.com'
+    - '.baz.com'
     ```
 
 3.  Copy your private SSH key to `genconf/ssh_key`. For more information, see the [ssh_key_path][6] parameter.

--- a/1.8/administration/installing/custom/configuration-parameters.md
+++ b/1.8/administration/installing/custom/configuration-parameters.md
@@ -157,9 +157,9 @@ This parameter specifies whether to enable the DC/OS proxy.
 *  `use_proxy: 'false'` Do not configure DC/OS [components](/docs/1.8/overview/components/) to use a custom proxy. This is the default value.
 *  `use_proxy: 'true'` Configure DC/OS [components](/docs/1.8/overview/components/) to use a custom proxy. If you specify `use_proxy: 'true'`, you can also specify these parameters:
     
-    *  `http_proxy: <your_http_proxy>` This parameter specifies the HTTP proxy.
-    *  `https_proxy: <your_https_proxy>` This parameter specifies the HTTPS proxy.
-    *  `no_proxy: - <ip-address>` This parameter specifies YAML nested list (-) of addresses to exclude from the proxy.
+    *  `http_proxy: http://<user>:<pass>@<proxy_host>:<http_proxy_port>` This parameter specifies the HTTP proxy.
+    *  `https_proxy: https://<user>:<pass>@<proxy_host>:<https_proxy_port>` This parameter specifies the HTTPS proxy.
+    *  `no_proxy: - .<(sub)domain>` This parameter specifies YAML nested list (-) of addresses to exclude from the proxy.
     
     **Important:** 
     
@@ -364,10 +364,11 @@ ssh_user: <username>
     ssh_port: 22
     ssh_user: centos
     use_proxy: 'true'
-    http_proxy: http://<your_http_proxy>/
-    https_proxy: https://<your_https_proxy>/
+    http_proxy: http://<proxy_host>:<http_proxy_port>
+    https_proxy: https://<proxy_host>:<https_proxy_port>
     no_proxy:
-    - '*.int.example.com'
+    - 'foo.bar.com'
+    - '.baz.com'
 ```
 
  [1]: https://en.wikipedia.org/wiki/YAML

--- a/1.8/usage/cli/configure.md
+++ b/1.8/usage/cli/configure.md
@@ -49,10 +49,10 @@ To configure a proxy for the CLI:
 
 *   From the CLI terminal, define the environment variables `http_proxy` and `https_proxy`:
     
-        $ export http_proxy=’<http://your/proxy/here/>’
-        $ export https_proxy=’<http://your/proxy/here/>’
+        $ export http_proxy=’http://<user>:<pass>@<proxy_host>:<http_proxy_port>’
+        $ export https_proxy=’https://<user>:<pass>@<proxy_host>:<https_proxy_port>’
         
 
 *   Define `no_proxy` for domains that you don’t want to use the proxy for:
     
-        $ export no_proxy="127.0.0.1, localhost”
+        $ export no_proxy=".mesos,.thisdcos.directory,.dcos.directory,.zk,127.0.0.1,localhost,foo.bar.com,.baz.com”

--- a/1.9/administration/installing/custom/advanced.md
+++ b/1.9/administration/installing/custom/advanced.md
@@ -82,10 +82,11 @@ The DC/OS installation creates these folders:
     - 8.8.4.4
     - 8.8.8.8
     use_proxy: 'true'
-    http_proxy: http://<your_http_proxy>/
-    https_proxy: https://<your_https_proxy>/
+    http_proxy: http://<proxy_host>:<http_proxy_port>
+    https_proxy: https://<proxy_host>:<https_proxy_port>
     no_proxy: 
-    - '*.int.example.com'    
+    - 'foo.bar.com'
+    - '.baz.com'
     ```
 
 2. Create a `ip-detect` script

--- a/1.9/administration/installing/custom/cli.md
+++ b/1.9/administration/installing/custom/cli.md
@@ -164,10 +164,11 @@ The DC/OS installation creates these folders:
     ssh_port: 22
     ssh_user: <username>
     use_proxy: 'true'
-    http_proxy: http://<your_http_proxy>/
-    https_proxy: https://<your_https_proxy>/
+    http_proxy: http://<proxy_host>:<http_proxy_port>
+    https_proxy: https://<proxy_host>:<https_proxy_port>
     no_proxy: 
-    - '*.int.example.com' 
+    - 'foo.bar.com'
+    - '.baz.com'
     ```
 
 3.  Copy your private SSH key to `genconf/ssh_key`. For more information, see the [ssh_key_path][6] parameter.

--- a/1.9/administration/installing/custom/configuration-parameters.md
+++ b/1.9/administration/installing/custom/configuration-parameters.md
@@ -200,9 +200,9 @@ This parameter specifies whether to enable the DC/OS proxy.
 *  `use_proxy: 'false'` Do not configure DC/OS [components](/docs/1.9/overview/architecture/components/) to use a custom proxy. This is the default value.
 *  `use_proxy: 'true'` Configure DC/OS [components](/docs/1.9/overview/architecture/components/) to use a custom proxy. If you specify `use_proxy: 'true'`, you can also specify these parameters:
     **Important:** The specified proxies must be resolvable from the provided list of [resolvers](#resolvers).
-    *  `http_proxy: <your_http_proxy>` This parameter specifies the HTTP proxy.
-    *  `https_proxy: <your_https_proxy>` This parameter specifies the HTTPS proxy.
-    *  `no_proxy: - <ip-address>` This parameter specifies YAML nested list (-) of addresses to exclude from the proxy.
+    *  `http_proxy: http://<user>:<pass>@<proxy_host>:<http_proxy_port>` This parameter specifies the HTTP proxy.
+    *  `https_proxy: https://<user>:<pass>@<proxy_host>:<https_proxy_port>` This parameter specifies the HTTPS proxy.
+    *  `no_proxy: - .<(sub)domain>` This parameter specifies YAML nested list (-) of addresses to exclude from the proxy.
 
 For more information, see the [examples](#http-proxy).
 
@@ -405,10 +405,11 @@ ssh_user: <username>
     ssh_port: 22
     ssh_user: centos
     use_proxy: 'true'
-    http_proxy: http://<your_http_proxy>/
-    https_proxy: https://<your_https_proxy>/
+    http_proxy: http://<proxy_host>:<http_proxy_port>
+    https_proxy: https://<proxy_host>:<https_proxy_port>
     no_proxy:
-    - '*.int.example.com'
+    - 'foo.bar.com'
+    - '.baz.com'
 ```
 
 #### <a name="docker-credentials"></a>DC/OS cluster with three masters, an Exhibitor/ZooKeeper managed internally, custom Docker credentials, two private agents, and Google DNS

--- a/1.9/usage/cli/configure.md
+++ b/1.9/usage/cli/configure.md
@@ -49,10 +49,10 @@ To configure a proxy for the CLI:
 
 *   From the CLI terminal, define the environment variables `http_proxy` and `https_proxy`:
     
-        $ export http_proxy=’<http://your/proxy/here/>’
-        $ export https_proxy=’<http://your/proxy/here/>’
+        $ export http_proxy=’http://<user>:<pass>@<proxy_host>:<http_proxy_port>’
+        $ export https_proxy=’https://<user>:<pass>@<proxy_host>:<https_proxy_port>’
         
 
 *   Define `no_proxy` for domains that you don’t want to use the proxy for:
     
-        $ export no_proxy="127.0.0.1, localhost”
+        $ export no_proxy=".mesos,.thisdcos.directory,.dcos.directory,.zk,127.0.0.1,localhost,foo.bar.com,.baz.com”


### PR DESCRIPTION
## Description
Fixup no_proxy directive and make http_proxy and https_proxy examples better as described in https://jira.mesosphere.com/browse/DOCS-1710

## Urgency
- [ ] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
