### PR TITLE
Fix pods killSelection example

### DIFF
--- a/1.9/usage/pods/examples.md
+++ b/1.9/usage/pods/examples.md
@@ -100,7 +100,7 @@ The following pod definition specifies a pod with 3 containers. <!-- Validated b
       "constraints": [],
       "acceptedResourceRoles": []
     },
-    "killSelection": "YoungestFirst",
+    "killSelection": "Youngest_First",
     "unreachableStrategy": {
       "inactiveAfterSeconds": 900,
       "expungeAfterSeconds": 604800
@@ -205,7 +205,7 @@ The following pod definition specifies an ephemeral volume called `v1`. <!-- Val
       "constraints": [],
       "acceptedResourceRoles": []
     },
-    "killSelection": "YoungestFirst",
+    "killSelection": "Youngest_First",
     "unreachableStrategy": {
       "inactiveAfterSeconds": 900,
       "expungeAfterSeconds": 604800
@@ -278,7 +278,7 @@ The following pod definition specifies a virtual (user) network named `dcos`. <!
       "constraints": [],
       "acceptedResourceRoles": []
     },
-    "killSelection": "YoungestFirst",
+    "killSelection": "Youngest_First",
     "unreachableStrategy": {
       "inactiveAfterSeconds": 900,
       "expungeAfterSeconds": 604800
@@ -358,7 +358,7 @@ This pod declares a “web” endpoint that listens on port 80. <!-- Validated b
       "constraints": [],
       "acceptedResourceRoles": []
     },
-    "killSelection": "YoungestFirst",
+    "killSelection": "Youngest_First",
     "unreachableStrategy": {
       "inactiveAfterSeconds": 900,
       "expungeAfterSeconds": 604800


### PR DESCRIPTION
## Description
Update the syntax for the killSelection in the pods example.

## Urgency
- [ ] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
