### PR TITLE
Update Marathon Swagger for 1.9

### DIFF
--- a/1.9/api/marathon.yaml
+++ b/1.9/api/marathon.yaml
@@ -1,128 +1,134 @@
-swagger: '2.0'
+swagger: 2.0
 info:
-  version: 2.0.0
+  version: 2.0
   title: Marathon REST API
-securityDefinitions: {}
-basePath: /v2
-tags:
-  - name: apps
-  - name: deployments
-  - name: groups
-  - name: artifacts
-  - name: events
-  - name: info
-  - name: leader
-  - name: plugins
-  - name: queue
-  - name: ping
-  - name: metrics
+  description: ''
+host: example.com
+basePath: /service/marathon
+schemes:
+- http
 consumes:
 - application/json
 produces:
 - application/json
 paths:
-  /apps/{app_id}/restart:
+  /v2/apps/{app_id}/restart:
     post:
       description: Restart all tasks of this application.
       tags:
-        - apps
+      - v2
       operationId: V2AppsRestartByAppId
       produces:
       - application/json
       parameters:
+      - name: app_id
+        in: path
+        required: true
+        type: string
       - name: force
         in: query
         required: false
-        x-is-map: false
+        default: false
         type: boolean
         description: >-
           Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
 
           Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
-      - name: app_id
-        in: path
-        required: true
-        x-is-map: false
-        type: string
       responses:
         200:
-          description: Success.
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
           schema:
-            $ref: '#/definitions/V2AppsRestartresponse'
+            type: string
         404:
           description: No task found with this `app_id`.
+          schema:
+            $ref: '#/definitions/Error'
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
         409:
           description: There is an already running deployment, that affects this application. To override this deployment, use the force=true flag
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /apps/{app_id}/tasks/{task_id}:
+  /v2/apps/{app_id}/tasks/{task_id}:
     delete:
       description: Kill the task with ID `task_id` that belongs to the application `app_id`.
       tags:
-      - apps
+      - v2
       operationId: V2AppsTasksByAppIdAndTaskId
       produces:
       - application/json
       parameters:
+      - name: app_id
+        in: path
+        required: true
+        type: string
+      - name: task_id
+        in: path
+        required: true
+        type: string
       - name: scale
         in: query
-        required: false
-        x-is-map: false
+        required: true
         type: boolean
         description: If `scale=true` is specified, then the application is scaled down by the number of killed tasks. Only possible if `wipe=false` or not specified.
       - name: wipe
         in: query
-        required: false
-        x-is-map: false
+        required: true
         type: boolean
         description: If `wipe=true` is specified and the app uses local persistent volumes, associated dynamic reservations will be unreserved, and persistent volumes will be destroyed. Only possible if `scale=false` or not specified.
       - name: force
         in: query
         required: false
-        x-is-map: false
+        default: false
         type: boolean
         description: >-
           Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
 
           Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
-      - name: app_id
-        in: path
-        required: true
-        x-is-map: false
-        type: string
-      - name: task_id
-        in: path
-        required: true
-        x-is-map: false
-        type: string
       responses:
         200:
-          description: Success.
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
+          schema:
+            type: string
         404:
           description: No task found with this task_id.
+          schema:
+            $ref: '#/definitions/Error'
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
         409:
           description: There is an already running deployment, that affects this application. To override this deployment, use the force=true flag
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /apps/{app_id}/tasks:
+  /v2/apps/{app_id}/tasks:
     get:
       description: List all running tasks for application `app_id`.
       tags:
-      - apps
+      - v2
       operationId: V2AppsTasksByAppId
       produces:
       - application/json
@@ -130,19 +136,25 @@ paths:
       - name: app_id
         in: path
         required: true
-        x-is-map: false
         type: string
       responses:
         200:
-          description: Lists running tasks for the application specified.
+          description: The list of running tasks for application `app_id`.
           schema:
-            $ref: '#/definitions/V2AppsTasksresponse'
+            type: string
         404:
           description: No task found with this `app_id`.
+          schema:
+            type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -151,64 +163,71 @@ paths:
     delete:
       description: Kill tasks that belong to the application `app_id`
       tags:
-      - apps
+      - v2
       operationId: V2AppsTasksByAppId1
       produces:
       - application/json
       parameters:
+      - name: app_id
+        in: path
+        required: true
+        type: string
       - name: host
         in: query
-        required: false
-        x-is-map: false
+        required: true
         type: string
         description: all tasks of that application on the supplied slave are killed
       - name: scale
         in: query
-        required: false
-        x-is-map: false
+        required: true
         type: boolean
         description: If `scale=true` is specified, then the application is scaled down by the number of killed tasks. Only possible if `wipe=false` or not specified.
       - name: wipe
         in: query
-        required: false
-        x-is-map: false
+        required: true
         type: boolean
         description: If `wipe=true` is specified and the app uses local persistent volumes, associated dynamic reservations will be unreserved, and persistent volumes will be destroyed. Only possible if `scale=false` or not specified.
       - name: force
         in: query
         required: false
-        x-is-map: false
+        default: false
         type: boolean
         description: >-
           Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
 
           Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
-      - name: app_id
-        in: path
-        required: true
-        x-is-map: false
-        type: string
       responses:
         200:
-          description: Success.
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
+          schema:
+            type: string
         404:
           description: No task found with this `app_id`.
+          schema:
+            type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
         409:
           description: There is an already running deployment, that affects this application. To override this deployment, use the force=true flag
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /apps/{app_id}/versions/{version}:
+  /v2/apps/{app_id}/versions/{version}:
     get:
       description: List the configuration of the application with id `app_id` at version `version`.
       tags:
-      - apps
+      - v2
       operationId: V2AppsVersionsByAppIdAndVersion
       produces:
       - application/json
@@ -216,34 +235,39 @@ paths:
       - name: app_id
         in: path
         required: true
-        x-is-map: false
         type: string
       - name: version
         in: path
         required: true
-        x-is-map: false
         type: string
       responses:
         200:
-          description: Lists app configuration.
+          description: The application definition at that point in time.
           schema:
-            $ref: '#/definitions/V2AppsVersionsresponse'
+            $ref: '#/definitions/App'
         404:
           description: No task found with this `app_id`.
+          schema:
+            type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /apps/{app_id}/versions:
+  /v2/apps/{app_id}/versions:
     get:
       description: List the versions of the application with id `app_id`
       tags:
-      - apps
+      - v2
       operationId: V2AppsVersionsByAppId
       produces:
       - application/json
@@ -251,37 +275,46 @@ paths:
       - name: app_id
         in: path
         required: true
-        x-is-map: false
         type: string
       responses:
         200:
-          description: Lists versions of the app specified.
+          description: The list of versions of the application
           schema:
-            $ref: '#/definitions/V2AppsVersionsresponse21'
+            type: string
         404:
           description: No task found with this `app_id`.
+          schema:
+            $ref: '#/definitions/Error'
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /apps/{app_id}:
+  /v2/apps/{app_id}:
     get:
       description: Get the application with id `app_id`. The response includes some status information besides the current configuration of the app. You can specify optional embed arguments, to get more embedded information.
       tags:
-      - apps
+      - v2
       operationId: V2AppsByAppId
       produces:
       - application/json
       parameters:
+      - name: app_id
+        in: path
+        required: true
+        type: string
       - name: embed
         in: query
-        required: false
-        x-is-map: false
+        required: true
         enum:
         - Enum_app.tasks
         - Enum_app.count
@@ -305,23 +338,25 @@ paths:
 
           - <code>app.failures</code> Shorthand for apps.lastTaskFailure, apps.tasks, apps.counts and apps.deployments.<br/> Note&#58; deprecated and will be removed in future versions Please define all embeds explicitly.
 
-          - <code>app.taskStats</code> exposes task statatistics in the JSON.
-      - name: app_id
-        in: path
-        required: true
-        x-is-map: false
-        type: string
+          - <code>app.taskStats</code> exposes task statistics in the JSON.
       responses:
         200:
-          description: Success
+          description: ''
           schema:
-            $ref: '#/definitions/V2Appsresponse'
+            type: string
         404:
           description: No task found with this `app_id`.
+          schema:
+            $ref: '#/definitions/Error'
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -334,48 +369,74 @@ paths:
 
         Note&#58;  This operation will create a deployment. The operation finishes, if the deployment succeeds. You can query the deployments endoint to see the status of the deployment.
       tags:
-      - apps
-      operationId: V2AppsByAppId1
+      - v2
+      operationId: V2AppsByAppId3
       produces:
       - application/json
       parameters:
+      - name: app_id
+        in: path
+        required: true
+        type: string
+      - name: partialUpdate
+        in: query
+        required: false
+        default: true
+        type: string
+        description: >
+          Without specifying this parameter, this method has a patch like semantic:
+
+          All values that are not defined in the json, will not change existing values.
+
+          This was the default behaviour in previous Marathon versions.
+
+          For backward compatibility, we will not change this behaviour, but let users opt in for a proper PUT.
+
+          Note: We will change the default behaviour in the next Marathon version to support PATCH and PUT as HTTP methods.
       - name: force
         in: query
         required: false
-        x-is-map: false
+        default: false
         type: boolean
         description: >-
           Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
 
           Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
-      - name: app_id
-        in: path
-        required: true
-        x-is-map: false
-        type: string
       - name: body
         in: body
         required: true
-        x-is-map: false
         schema:
-          $ref: '#/definitions/AppDefinition'
+          $ref: '#/definitions/App'
       responses:
         200:
-          description: Success.
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
           schema:
-            $ref: '#/definitions/V2AppsRestartresponse'
+            type: string
         404:
           description: No task found with this `app_id`.
+          schema:
+            $ref: '#/definitions/Error'
         400:
           description: The application definition provided in the body is not valid.
+          schema:
+            $ref: '#/definitions/Error'
         422:
-          description: The entity send can not be preocessed, since there are validation errors
+          description: The entity sent can not be preocessed, since there are validation errors
+          schema:
+            $ref: '#/definitions/Error'
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
         409:
           description: There is an already running deployment, that affects this application. To override this deployment, use the force=true flag
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -387,46 +448,120 @@ paths:
 
         Note&#58;  This operation will create a deployment. The operation finishes, if the deployment succeeds. You can query the deployments endoint to see the status of the deployment.
       tags:
-      - apps
+      - v2
       operationId: V2AppsByAppId2
       produces:
       - application/json
       parameters:
+      - name: app_id
+        in: path
+        required: true
+        type: string
       - name: force
         in: query
         required: false
-        x-is-map: false
+        default: false
         type: boolean
         description: >-
           Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
 
           Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
-      - name: app_id
-        in: path
-        required: true
-        x-is-map: false
-        type: string
       responses:
         200:
-          description:  Success.
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
+          schema:
+            type: string
         404:
           description: No app with this id known.
+          schema:
+            $ref: '#/definitions/Error'
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
         409:
           description: There is an already running deployment, that affects this application. To override this deployment, use the force=true flag
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /apps:
+    patch:
+      description: >-
+        Replaces parameters of a running application. All running instances get upgraded to the new definition. Any given application ID will be ignored.
+
+        Note&#58;  This operation will create a deployment. The operation finishes, if the deployment succeeds. You can query the deployments endoint to see the status of the deployment.
+      tags:
+      - v2
+      operationId: V2AppsByAppId1
+      produces:
+      - application/json
+      parameters:
+      - name: app_id
+        in: path
+        required: true
+        type: string
+      - name: force
+        in: query
+        required: false
+        default: false
+        type: boolean
+        description: >-
+          Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
+
+          Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/App'
+      responses:
+        200:
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
+          schema:
+            type: string
+        404:
+          description: No task found with this `app_id`.
+          schema:
+            $ref: '#/definitions/Error'
+        400:
+          description: The application definition provided in the body is not valid.
+          schema:
+            $ref: '#/definitions/Error'
+        422:
+          description: The entity sent can not be preocessed, since there are validation errors
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+        409:
+          description: There is an already running deployment, that affects this application. To override this deployment, use the force=true flag
+          schema:
+            type: string
+      x-unitTests: []
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  /v2/apps:
     get:
       description: Get the list of running applications. Several filters can be applied via the following query parameters.
       tags:
-      - apps
+      - v2
       operationId: V2Apps
       produces:
       - application/json
@@ -434,19 +569,16 @@ paths:
       - name: cmd
         in: query
         required: false
-        x-is-map: false
         type: string
         description: Filter the result to only return apps whose `cmd` field contains the given value
       - name: id
         in: query
         required: false
-        x-is-map: false
         type: string
         description: Filter the result to only return apps whose `id` is or contains the given value
       - name: label
         in: query
         required: false
-        x-is-map: false
         type: string
         description: >-
           A label selector query contains one or more label selectors, which are comma separated. Marathon supports three types of selectors existence-based, equality-based and set-based. In the case of multiple selectors, all must be satisfied so comma separator acts as an AND logical operator. Labels and values must consist of alphanumeric characters plus `-` `_` and `.` `-A-Za-z0-9_.`. Any other character is possible, but must be escaped with a backslash character.
@@ -459,7 +591,6 @@ paths:
       - name: embed
         in: query
         required: false
-        x-is-map: false
         enum:
         - Enum_apps.tasks
         - Enum_apps.count
@@ -483,16 +614,36 @@ paths:
 
           - <code>apps.failures</code> Shorthand for apps.lastTaskFailure, apps.tasks, apps.counts and apps.deployments.<br/> Note&#58; deprecated and will be removed in future versions Please define all embeds explicitly.
 
-          - <code>apps.taskStats</code> exposes task statatistics in the JSON.
+          - <code>apps.taskStats</code> exposes task statistics in the JSON.
       responses:
         200:
-          description: Lists running applications.
+          description: The list of applications that match the defined filters
           schema:
-            $ref: '#/definitions/V2Appsresponse'
+            type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: GET
+          uri: /v2/apps?cmd=java&id=/us-east/database/memsql&label=my_label, environment==production, tier!=frontend\ tier, deployed in (us, eu), deployed notin (aa, bb)&embed=apps.tasks
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: RAW
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+          body: '{  "apps": [    {      "id": "/myapp",      "cmd": "env && sleep 60",      "args": null,      "user": null,      "env": {        "LD_LIBRARY_PATH": "/usr/local/lib/myLib"      },      "instances": 3,      "cpus": 0.1,      "mem": 5,      "disk": 0,      "executor": "",      "constraints": [        [          "hostname",          "UNIQUE",          ""        ]      ],      "uris": [        "https://raw.github.com/mesosphere/marathon/master/README.md"      ],      "storeUrls": [],      "ports": [        10013,        10015      ],      "requirePorts": false,      "backoffSeconds": 1,      "backoffFactor": 1.15,      "maxLaunchDelaySeconds": 3600,      "container": null,      "healthChecks": [],      "dependencies": [],      "upgradeStrategy": {        "minimumHealthCapacity": 1,        "maximumOverCapacity": 1      },      "labels": {},      "acceptedResourceRoles": null,      "version": "2015-09-25T15:13:48.343Z",      "versionInfo": {        "lastScalingAt": "2015-09-25T15:13:48.343Z",        "lastConfigChangeAt": "2015-09-25T15:13:48.343Z"      },      "tasksStaged": 0,      "tasksRunning": 0,      "tasksHealthy": 0,      "tasksUnhealthy": 0,      "deployments": [        {          "id": "9538079c-3898-4e32-aa31-799bf9097f74"        }      ]    }  ]}'
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2Apps1
+        x-testDescription: Get the list of running applications. Several filters can be applied via the following query parameters.
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -508,15 +659,30 @@ paths:
 
         Note&#58;  This operation will create a deployment. The operation finishes, if the deployment succeeds. You can query the deployments endoint to see the status of the deployment.
       tags:
-      - apps
-      operationId: V2Apps1
+      - v2
+      operationId: V2Apps3
       produces:
       - application/json
       parameters:
+      - name: partialUpdate
+        in: query
+        required: false
+        default: true
+        type: string
+        description: >
+          Without specifying this parameter, this method has a patch like semantic:
+
+          All values that are not defined in the json, will not change existing values.
+
+          This was the default behaviour in previous Marathon versions.
+
+          For backward compatibility, we will not change this behaviour, but let users opt in for a proper PUT.
+
+          Note: We will change the default behaviour in the next Marathon version to support PATCH and PUT as HTTP methods.
       - name: force
         in: query
         required: false
-        x-is-map: false
+        default: false
         type: boolean
         description: >-
           Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
@@ -525,24 +691,36 @@ paths:
       - name: body
         in: body
         required: true
-        x-is-map: false
         schema:
-          type: string
+          type: array
+          items:
+            $ref: '#/definitions/App'
       responses:
         200:
-          description: Success.
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
           schema:
-            $ref: '#/definitions/V2AppsRestartresponse'
+            type: string
         409:
           description: There is an already deployed application with this name
+          schema:
+            $ref: '#/definitions/Error'
         400:
           description: The application definition provided in the body is not valid.
+          schema:
+            $ref: '#/definitions/Error'
         422:
           description: The entity send can not be preocessed, since there are validation errors
+          schema:
+            $ref: '#/definitions/Error'
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -554,72 +732,644 @@ paths:
 
         Note&#58;  This operation will create a deployment. The operation finishes, if the deployment succeeds. You can query the deployments endoint to see the status of the deployment.
       tags:
-      - apps
-      operationId: V2Apps2
-      produces:
-      - application/json
-      parameters:
-      - name: body
-        in: body
-        required: true
-        x-is-map: false
-        schema:
-          $ref: '#/definitions/AppDefinition'
-      responses:
-        200:
-          description: Success.
-          schema:
-            $ref: '#/definitions/V2AppsVersionsresponse'
-        409:
-          description: There is an already deployed application with this name
-        400:
-          description: The application definition provided in the body is not valid.
-        422:
-          description: The entity send can not be preocessed, since there are validation errors
-        401:
-          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
-        403:
-          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
-      x-operation-settings:
-        CollectParameters: false
-        AllowDynamicQueryParameters: false
-        AllowDynamicFormParameters: false
-        IsMultiContentStreaming: false
-  /deployments/{deployment_id}:
-    delete:
-      description: Revert the deployment with `deployment_id` by creating a new deployment which reverses all changes.
-      tags:
-      - deployments
-      operationId: V2DeploymentsByDeploymentId
+      - v2
+      operationId: V2Apps1
       produces:
       - application/json
       parameters:
       - name: force
         in: query
         required: false
-        x-is-map: false
+        default: false
         type: boolean
-        description: If set to <code>false</code> (the default) then the deployment is canceled and a new deployment is created to revert the changes of this deployment. Without concurrent deployments, this restores the configuration before this deployment. If set to <code>true</code>, then the deployment is still canceled but no rollback deployment is created.
-      - name: deployment_id
-        in: path
+        description: >-
+          Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
+
+          Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
+      - name: body
+        in: body
         required: true
-        x-is-map: false
-        type: string
+        schema:
+          $ref: '#/definitions/App'
       responses:
         200:
-          description: Success.
-        404:
-          description: The deployment plan with the given id can not be found.
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
+          schema:
+            type: string
+        409:
+          description: There is an already deployed application with this name
+          schema:
+            $ref: '#/definitions/Error'
+        400:
+          description: The application definition provided in the body is not valid.
+          schema:
+            $ref: '#/definitions/Error'
+        422:
+          description: The entity send can not be preocessed, since there are validation errors
+          schema:
+            $ref: '#/definitions/Error'
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /deployments:
+    patch:
+      description: >-
+        Change multiple existing applications by applying a patch. All instances of these applications get replaced by the new version. The order of dependencies will be applied correctly. Each upgradeStrategy defines the behaviour of the upgrade for the related app.
+
+        The whole operation fails if the IDs of one or more applications are unknown. The order of dependencies will be applied correctly.
+
+        If you have more complex scenarios with upgrades, use the groups endpoint.
+
+        Note&#58;  This operation will create a deployment. The operation finishes, if the deployment succeeds. You can query the deployments endoint to see the status of the deployment.
+      tags:
+      - v2
+      operationId: V2Apps2
+      produces:
+      - application/json
+      parameters:
+      - name: force
+        in: query
+        required: false
+        default: false
+        type: boolean
+        description: >-
+          Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
+
+          Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
+      - name: body
+        in: body
+        required: true
+        schema:
+          type: array
+          items:
+            $ref: '#/definitions/App'
+      responses:
+        200:
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
+          schema:
+            type: string
+        409:
+          description: One or more specified applications is currently locked by a deployment
+          schema:
+            $ref: '#/definitions/Error'
+        400:
+          description: The application definition provided in the body is not valid.
+          schema:
+            $ref: '#/definitions/Error'
+        422:
+          description: The entity send can not be processed, since there are validation errors
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  /v2/pods/:
+    get:
+      description: >
+        List all the pod-based services in the system.
+      tags:
+      - v2
+      operationId: V2Pods
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        200:
+          description: >
+            Yields a list of all pods in the system.
+
+            Useful to perform backups of all pods registered with Marathon.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Pod'
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: GET
+          uri: /v2/pods/
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: NONE
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2Pods1
+        x-testDescription: >
+          List all the pod-based services in the system.
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+    post:
+      description: >
+        Create and start a new pod-based service.
+      tags:
+      - v2
+      operationId: V2Pods1
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/Pod'
+      responses:
+        200:
+          description: Pod created successfully.
+          schema:
+            $ref: '#/definitions/Pod'
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+        400:
+          description: Invalid JSON syntax.
+          schema:
+            type: string
+        422:
+          description: Invalid object specification, one or more specification rules have been violated.
+          schema:
+            type: string
+        409:
+          description: Duplicate object ID. Another app, group, or pod already exists for the specified ID.
+          schema:
+            type: string
+      x-unitTests: []
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  /v2/pods/::status:
+    get:
+      description: Get the status for all pods
+      tags:
+      - v2
+      operationId: V2PodsStatus
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        200:
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/PodStatus'
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+        404:
+          description: Unknown object ID. No such app, group, or pod exists for the specified ID.
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: GET
+          uri: /v2/pods/::status
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: NONE
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2PodsStatus1
+        x-testDescription: Get the status for all pods
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  /v2/pods/{id}:
+    get:
+      description: >
+        Get the pod at the given id
+      tags:
+      - v2
+      operationId: V2PodsById
+      produces:
+      - application/json
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: The path of the pod
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/Pod'
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+        404:
+          description: Unknown object ID. No such app, group, or pod exists for the specified ID.
+          schema:
+            type: string
+      x-unitTests: []
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+    put:
+      description: >
+        Update an existing pod-based service.
+      tags:
+      - v2
+      operationId: V2PodsById2
+      produces:
+      - application/json
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: The path of the pod
+      - name: force
+        in: query
+        required: false
+        default: false
+        type: boolean
+        description: >-
+          Only one deployment can be applied to one pod at the same time. If the existing deployment should be canceled by this change, you can set force=true.
+
+          Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/Pod'
+      responses:
+        200:
+          description: The pod has been updated and a deployment is started.
+          schema:
+            $ref: '#/definitions/Pod'
+        400:
+          description: The given podId does not match the id in the pod specification.
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+        422:
+          description: Invalid object specification, one or more specification rules have been violated.
+          schema:
+            type: string
+        404:
+          description: Unknown object ID. No such app, group, or pod exists for the specified ID.
+          schema:
+            type: string
+      x-unitTests: []
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+    delete:
+      description: >
+        Delete an existing pod-based service.
+      tags:
+      - v2
+      operationId: V2PodsById1
+      produces:
+      - application/json
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: The path of the pod
+      responses:
+        200:
+          description: ''
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+        404:
+          description: Unknown object ID. No such app, group, or pod exists for the specified ID.
+          schema:
+            type: string
+      x-unitTests: []
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  /v2/pods/{id}::status:
+    get:
+      description: >
+        Get the status of the pod with the given id
+      tags:
+      - v2
+      operationId: V2PodsStatusById
+      produces:
+      - application/json
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: The path of the pod
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/PodStatus'
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+        404:
+          description: Unknown object ID. No such app, group, or pod exists for the specified ID.
+          schema:
+            type: string
+      x-unitTests: []
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  /v2/pods/{id}::versions:
+    get:
+      description: >
+        List the versions of this pod.
+      tags:
+      - v2
+      operationId: V2PodsVersionsById
+      produces:
+      - application/json
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: The path of the pod
+      responses:
+        200:
+          description: ''
+          schema:
+            type: array
+            items:
+              type: string
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+        404:
+          description: Unknown object ID. No such app, group, or pod exists for the specified ID.
+          schema:
+            type: string
+      x-unitTests: []
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  /v2/pods/{id}::versions/{version}:
+    get:
+      description: >
+        List the versions of this pod.
+      tags:
+      - v2
+      operationId: V2PodsVersionsByIdAndVersion
+      produces:
+      - application/json
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: The path of the pod
+      - name: version
+        in: path
+        required: true
+        type: string
+        description: The version of the pod
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/Pod'
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+        404:
+          description: Unknown object ID. No such app, group, or pod exists for the specified ID.
+          schema:
+            type: string
+      x-unitTests: []
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  /v2/pods/{id}::instances/{instance}:
+    delete:
+      description: >
+        Kill the given instance of the pod
+      tags:
+      - v2
+      operationId: V2PodsInstancesByIdAndInstance
+      produces:
+      - application/json
+      parameters:
+      - name: instance
+        in: path
+        required: true
+        type: string
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: The path of the pod
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/PodInstanceStatus'
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+        404:
+          description: Unknown object ID. No such app, group, or pod exists for the specified ID.
+          schema:
+            type: string
+      x-unitTests: []
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  /v2/pods/{id}::instances:
+    delete:
+      description: >
+        Kill the given instances of the pod
+      tags:
+      - v2
+      operationId: V2PodsInstancesById
+      produces:
+      - application/json
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: The path of the pod
+      - name: body
+        in: body
+        required: true
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        200:
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/PodInstanceStatus'
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+        404:
+          description: Unknown object ID. No such app, group, or pod exists for the specified ID.
+          schema:
+            type: string
+      x-unitTests: []
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  /v2/deployments/{deployment_id}:
+    delete:
+      description: Revert the deployment with `deployment_id` by creating a new deployment which reverses all changes.
+      tags:
+      - v2
+      operationId: V2DeploymentsByDeploymentId
+      produces:
+      - application/json
+      parameters:
+      - name: deployment_id
+        in: path
+        required: true
+        type: string
+      - name: force
+        in: query
+        required: true
+        type: boolean
+        description: If set to <code>false</code> (the default) then the deployment is canceled and a new deployment is created to revert the changes of this deployment. Without concurrent deployments, this restores the configuration before this deployment. If set to <code>true</code>, then the deployment is still canceled but no rollback deployment is created. <br><br> **Warning** - Using <code>force=true</code> to abort a deployment can leave behind unaccounted for tasks and/or leave the app in a mixed state of old and new versions of tasks!
+      responses:
+        200:
+          description: If the force flag is set to true, the deployment is canceled and no new deployment is triggered. In this case no body is returned.
+          schema:
+            type: string
+        404:
+          description: The deployment plan with the given id can not be found.
+          schema:
+            type: string
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  /v2/deployments:
     get:
       description: >-
         List all running deployments. A deployment is a change in the service setup.
@@ -636,57 +1386,126 @@ paths:
 
         * <code>RestartApplication</code> upgrades an already deployed application with a new version.
 
+        * <code>StartPod</code> starts a pod, which is currently not running.
+
+        * <code>StopPod</code> stops an already running pod.
+
+        * <code>ScalePod</code> changes the number of instances of an pod and allows to kill specified instances while scaling.
+
+        * <code>RestartPod</code> upgrades an already deployed pod with a new version.
+
         * <code>ResolveArtifacts</code> Resolve all artifacts of an application
       tags:
-      - deployments
+      - v2
       operationId: V2Deployments
       produces:
       - application/json
       parameters: []
       responses:
         200:
-          description: Lists running deployments.
+          description: The list of all running deployments.
           schema:
             type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: GET
+          uri: /v2/deployments
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: RAW
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+          body: '[  {    "id": "97c136bf-5a28-4821-9d94-480d9fbb01c8",    "version": "2015-09-30T09:09:17.614Z",    "affectedApps": [      "/foo"    ],    "affectedPods": [      "/bla"    ],    "steps": [      {        "actions": [          {            "action": "ScaleApplication",            "app": "/foo"          }        ]      },      {        "actions": [          {            "action": "ScalePod",            "pod": "/bla"          }        ]      }    ],    "currentActions": [      {        "action": "ScaleApplication",        "app": "/foo",        "readinessCheckResults": [          {            "taskId": "foo.c9de6033",            "lastResponse": {              "body": "{}",              "contentType": "application/json",              "status": 500            },            "name": "myReadyCheck",            "ready": false          }        ]      }    ],    "currentStep": 1,    "totalSteps": 1  }]'
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2Deployments1
+        x-testDescription: >-
+          List all running deployments. A deployment is a change in the service setup.
+
+          A deployment is identified by an id, affects a set of applications and is composed of deployment steps.
+
+          Every step contains a list of actions with following types
+
+          * <code>StartApplication</code> starts an application, which is currently not running.
+
+          * <code>StopApplication</code> stops an already running application.
+
+          * <code>ScaleApplication</code> changes the number of instances of an application and allows to kill specified instances while scaling.
+
+          * <code>RestartApplication</code> upgrades an already deployed application with a new version.
+
+          * <code>StartPod</code> starts a pod, which is currently not running.
+
+          * <code>StopPod</code> stops an already running pod.
+
+          * <code>ScalePod</code> changes the number of instances of an pod and allows to kill specified instances while scaling.
+
+          * <code>RestartPod</code> upgrades an already deployed pod with a new version.
+
+          * <code>ResolveArtifacts</code> Resolve all artifacts of an application
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /groups/versions:
+  /v2/groups//versions:
     get:
-      description: List all versions of the group with the specified path.
+      description: List all versions the group with the specified path.
       tags:
-      - groups
+      - v2
       operationId: V2GroupsVersions
       produces:
       - application/json
       parameters: []
       responses:
         200:
-          description: Lists all versions of the group with the specified path.
+          description: List all available versions of that group.
           schema:
-            type: array
-            items:
-              type: string
+            type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: GET
+          uri: /v2/groups//versions
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: RAW
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+          body: '[ "2015-09-25T15:13:48.343Z", "2015-09-11T11:11:22.692Z", "2015-09-11T10:47:21.241Z" ]'
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2GroupsVersions1
+        x-testDescription: List all versions the group with the specified path.
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /groups:
+  /v2/groups/:
     get:
       description: Get the group with all applications and all transitive child groups.
       tags:
-      - groups
+      - v2
       operationId: V2Groups
       produces:
       - application/json
@@ -694,7 +1513,6 @@ paths:
       - name: embed
         in: query
         required: false
-        x-is-map: false
         enum:
         - Enum_group.groups
         - Enum_group.apps
@@ -725,108 +1543,73 @@ paths:
           - <code>group.apps.taskStats</code> exposes task statistics in the JSON.
       responses:
         200:
-          description: Success.
+          description: The group with all transitive dependencies.
           schema:
             $ref: '#/definitions/Group'
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: GET
+          uri: /v2/groups/?embed=group.apps
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: RAW
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+          body: '{  "id": "/",  "apps": [],  "groups": [    {      "id": "/tools",      "apps": [        {          "id": "/tools/oauth-server",          "instances": 2,          "cpus": 1,          "mem": 1024,          "disk": 0,          "constraints": [            [              "hostname",              "UNIQUE"            ]          ],          "uris": [],          "storeUrls": [],          "ports": [            1980          ],          "requirePorts": false,          "backoffSeconds": 1,          "backoffFactor": 1.15,          "maxLaunchDelaySeconds": 3600,          "container": {            "type": "DOCKER",            "volumes": [],            "docker": {              "image": "docker-registry/oauth_server:6d7d463cb8b1517002080a81cf23f9cf7b7fc774",              "network": "HOST",              "privileged": false,              "parameters": [],              "forcePullImage": false            }          },          "healthChecks": [            {              "path": "/",              "protocol": "HTTP",              "portIndex": 0,              "gracePeriodSeconds": 300,              "intervalSeconds": 20,              "timeoutSeconds": 20,              "maxConsecutiveFailures": 3,              "ignoreHttp1xx": false            }          ],          "dependencies": [],          "upgradeStrategy": {            "minimumHealthCapacity": 0.5,            "maximumOverCapacity": 0          },          "version": "2015-09-28T19:47:37.681Z",          "versionInfo": {            "lastScalingAt": "2015-09-28T19:47:37.681Z",            "lastConfigChangeAt": "2015-09-28T19:47:37.681Z"          }        },        {          "id": "/tools/datadog-agent",          "instances": 5,          "cpus": 1,          "mem": 512,          "disk": 0,          "executor": "",          "constraints": [            [              "hostname",              "UNIQUE"            ]          ],          "uris": [],          "storeUrls": [],          "ports": [            10018          ],          "requirePorts": false,          "backoffSeconds": 1,          "backoffFactor": 1.15,          "maxLaunchDelaySeconds": 3600,          "container": {            "type": "DOCKER",            "volumes": [              {                "containerPath": "/var/run/docker.sock",                "hostPath": "/var/run/docker.sock",                "mode": "RW"              },              {                "containerPath": "/host/proc/mounts",                "hostPath": "/proc/mounts",                "mode": "RO"              },              {                "containerPath": "/host/sys/fs/cgroup",                "hostPath": "/sys/fs/cgroup/",                "mode": "RO"              }            ],            "docker": {              "image": "datadog/docker-dd-agent:latest",              "network": "HOST",              "privileged": true,              "parameters": [],              "forcePullImage": false            }          },          "healthChecks": [],          "dependencies": [],          "upgradeStrategy": {            "minimumHealthCapacity": 0.5,            "maximumOverCapacity": 0          },          "version": "2015-08-26T22:33:24.225Z",          "versionInfo": {            "lastScalingAt": "2015-08-26T22:33:24.225Z",            "lastConfigChangeAt": "2015-05-19T13:59:18.899Z"          }        }      ],      "groups": [        {          "id": "/tools/log",          "apps": [],          "groups": [],          "dependencies": [],          "version": "2015-09-17T10:38:20.875Z"        },        {          "id": "/tools/docker",          "apps": [            {              "id": "/tools/docker/registry",              "instances": 1,              "cpus": 0.5,              "mem": 4096,              "disk": 0,              "executor": "",              "constraints": [],              "uris": [],              "storeUrls": [],              "ports": [                5000              ],              "requirePorts": false,              "backoffSeconds": 1,              "backoffFactor": 1.15,              "maxLaunchDelaySeconds": 3600,              "container": {                "type": "DOCKER",                "volumes": [                  {                    "containerPath": "/docker_storage",                    "hostPath": "/hdd/tools/docker/registry",                    "mode": "RW"                  }                ],                "docker": {                  "image": "registry",                  "network": "BRIDGE",                  "portMappings": [                    {                      "containerPort": 5000,                      "hostPort": 0,                      "servicePort": 5000,                      "protocol": "tcp"                    }                  ],                  "privileged": false,                  "parameters": [],                  "forcePullImage": false                }              },              "healthChecks": [],              "dependencies": [],              "upgradeStrategy": {                "minimumHealthCapacity": 1,                "maximumOverCapacity": 1              },              "version": "2015-08-19T21:26:47.616Z",              "versionInfo": {                "lastScalingAt": "2015-08-19T21:26:47.616Z",                "lastConfigChangeAt": "2015-08-19T21:00:54.621Z"              }            }          ],          "groups": [],          "dependencies": [],          "version": "2015-09-17T10:38:20.875Z"        }      ],      "dependencies": [],      "version": "2015-09-17T10:38:20.875Z"    }  ],  "dependencies": [],  "version": "2015-09-17T10:38:20.875Z"}'
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2Groups1
+        x-testDescription: Get the group with all applications and all transitive child groups.
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
     put:
-      description: "Change parameters of a deployed application group. The new group parameters get applied.\n\n* Changes to application parameters will result in a restart of this application.\n* A new application added to the group will be started.\n* An existing application removed from the group will be stopped.\n\nIf there are no changes to the application definition, no restart is triggered. During restart marathon keeps track, that the configured amount of minimal running instances are _always_ available.\nThis method allows 2 special modes for the update operation>\n\n* Provide only the `version` field in the group definition. This will rollback the group to that given version\n* Provide only the `scaleBy` field will scale all transitive applications instance counts by the given factor.\n\nWhen one of version or scaleBy are set, nothing else than a version change or transitive instance count scaling will be applied. If both version and scaleBy are set, only a version rollback will be performed – the scaleBy value will not be applied.\nA deployment can run forever. This is the case, when the new application has a problem and does not become healthy. In this case, human interaction is needed with 2 possible choices\n\n* Rollback to an existing older version\n* Update with a newer version of the group which does not have the problems of the old one.\n\nSince the deployment of the group can take a considerable amount of time, this endpoint returns immediately with a version. The failure or success of the action is signalled via event. There is a group_change_success and group_change_failed with the given version."
-      tags:
-      - groups
-      operationId: V2Groups1
-      produces:
-      - application/json
-      parameters:
-      - name: force
-        in: query
-        required: false
-        x-is-map: false
-        type: boolean
-        description: >-
-          Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
+      description: >-
+        Change parameters of a deployed application group. The new group parameters get applied.
 
-          Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
-      - name: body
-        in: body
-        required: true
-        x-is-map: false
-        schema:
-          $ref: '#/definitions/Group'
-      responses:
-        200:
-          description: Success.
-          schema:
-            $ref: '#/definitions/V2AppsRestartresponse'
-        400:
-          description: The group definition provided in the body is not valid.
-        422:
-          description: The entity send can not be preocessed, since there are validation errors
-        401:
-          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
-        403:
-          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
-        409:
-          description: There is an already running deployment, that affects this application. To override this deployment, use the force=true flag
-      x-operation-settings:
-        CollectParameters: false
-        AllowDynamicQueryParameters: false
-        AllowDynamicFormParameters: false
-        IsMultiContentStreaming: false
-    post:
-      description: Create and start a new application group. Application groups can contain other application groups.
-      tags:
-      - groups
-      operationId: V2Groups2
-      produces:
-      - application/json
-      parameters:
-      - name: force
-        in: query
-        required: false
-        x-is-map: false
-        type: boolean
-        description: >-
-          Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
 
-          Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
-      - name: body
-        in: body
-        required: true
-        x-is-map: false
-        schema:
-          $ref: '#/definitions/Group'
-      responses:
-        200:
-          description: Success.
-          schema:
-            $ref: '#/definitions/V2AppsRestartresponse'
-        400:
-          description: The group definition provided in the body is not valid.
-        409:
-          description: There is an already deployed group with this name
-        422:
-          description: The entity send can not be preocessed, since there are validation errors
-        401:
-          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
-        403:
-          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
-      x-operation-settings:
-        CollectParameters: false
-        AllowDynamicQueryParameters: false
-        AllowDynamicFormParameters: false
-        IsMultiContentStreaming: false
-    delete:
-      description: Destroy a group. All data about that group and all associated applications will be deleted. The failure or success of the action is signalled via events. There is a group_change_success and group_change_failed with the given version.
+        * Changes to application parameters will result in a restart of this application.
+
+        * A new application added to the group will be started.
+
+        * An existing application removed from the group will be stopped.
+
+
+        If there are no changes to the application definition, no restart is triggered. During restart marathon keeps track, that the configured amount of minimal running instances are _always_ available.
+
+        This method allows 2 special modes for the update operation>
+
+
+        * Provide only the `version` field in the group definition. This will rollback the group to that given version
+
+        * Provide only the `scaleBy` field will scale all transitive applications instance counts by the given factor.
+
+
+        When one of version or scaleBy are set, nothing else than a version change or transitive instance count scaling will be applied. If both version and scaleBy are set, only a version rollback will be performed â the scaleBy value will not be applied.
+
+        A deployment can run forever. This is the case, when the new application has a problem and does not become healthy. In this case, human interaction is needed with 2 possible choices
+
+
+        * Rollback to an existing older version
+
+        * Update with a newer version of the group which does not have the problems of the old one.
+
+
+        Since the deployment of the group can take a considerable amount of time, this endpoint returns immediately with a version. The failure or success of the action is signalled via event. There is a group_change_success and group_change_failed with the given version.
       tags:
-      - groups
+      - v2
       operationId: V2Groups3
       produces:
       - application/json
@@ -834,7 +1617,178 @@ paths:
       - name: force
         in: query
         required: false
-        x-is-map: false
+        default: false
+        type: boolean
+        description: >-
+          Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
+
+          Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/Group'
+      responses:
+        200:
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
+          schema:
+            type: string
+        400:
+          description: The group definition provided in the body is not valid.
+          schema:
+            type: string
+        422:
+          description: The entity send can not be preocessed, since there are validation errors
+          schema:
+            type: string
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+        409:
+          description: There is an already running deployment, that affects this application. To override this deployment, use the force=true flag
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: PUT
+          uri: /v2/groups/?force=false
+          headers:
+            Content-Type: application/json
+          body: '{  "id": "/",  "apps": [],  "groups": [    {      "id": "/tools",      "apps": [        {          "id": "/tools/oauth-server",          "instances": 2,          "cpus": 1,          "mem": 1024,          "disk": 0,          "constraints": [            [              "hostname",              "UNIQUE"            ]          ],          "uris": [],          "storeUrls": [],          "ports": [            1980          ],          "requirePorts": false,          "backoffSeconds": 1,          "backoffFactor": 1.15,          "maxLaunchDelaySeconds": 3600,          "container": {            "type": "DOCKER",            "volumes": [],            "docker": {              "image": "docker-registry/oauth_server:6d7d463cb8b1517002080a81cf23f9cf7b7fc774",              "network": "HOST",              "privileged": false,              "parameters": [],              "forcePullImage": false            }          },          "healthChecks": [            {              "path": "/",              "protocol": "HTTP",              "portIndex": 0,              "gracePeriodSeconds": 300,              "intervalSeconds": 20,              "timeoutSeconds": 20,              "maxConsecutiveFailures": 3,              "ignoreHttp1xx": false            }          ],          "dependencies": [],          "upgradeStrategy": {            "minimumHealthCapacity": 0.5,            "maximumOverCapacity": 0          },          "version": "2015-09-28T19:47:37.681Z",          "versionInfo": {            "lastScalingAt": "2015-09-28T19:47:37.681Z",            "lastConfigChangeAt": "2015-09-28T19:47:37.681Z"          }        },        {          "id": "/tools/datadog-agent",          "instances": 5,          "cpus": 1,          "mem": 512,          "disk": 0,          "executor": "",          "constraints": [            [              "hostname",              "UNIQUE"            ]          ],          "uris": [],          "storeUrls": [],          "ports": [            10018          ],          "requirePorts": false,          "backoffSeconds": 1,          "backoffFactor": 1.15,          "maxLaunchDelaySeconds": 3600,          "container": {            "type": "DOCKER",            "volumes": [              {                "containerPath": "/var/run/docker.sock",                "hostPath": "/var/run/docker.sock",                "mode": "RW"              },              {                "containerPath": "/host/proc/mounts",                "hostPath": "/proc/mounts",                "mode": "RO"              },              {                "containerPath": "/host/sys/fs/cgroup",                "hostPath": "/sys/fs/cgroup/",                "mode": "RO"              }            ],            "docker": {              "image": "datadog/docker-dd-agent:latest",              "network": "HOST",              "privileged": true,              "parameters": [],              "forcePullImage": false            }          },          "healthChecks": [],          "dependencies": [],          "upgradeStrategy": {            "minimumHealthCapacity": 0.5,            "maximumOverCapacity": 0          },          "version": "2015-08-26T22:33:24.225Z",          "versionInfo": {            "lastScalingAt": "2015-08-26T22:33:24.225Z",            "lastConfigChangeAt": "2015-05-19T13:59:18.899Z"          }        }      ],      "groups": [        {          "id": "/tools/log",          "apps": [],          "groups": [],          "dependencies": [],          "version": "2015-09-17T10:38:20.875Z"        },        {          "id": "/tools/docker",          "apps": [            {              "id": "/tools/docker/registry",              "instances": 1,              "cpus": 0.5,              "mem": 4096,              "disk": 0,              "executor": "",              "constraints": [],              "uris": [],              "storeUrls": [],              "ports": [                5000              ],              "requirePorts": false,              "backoffSeconds": 1,              "backoffFactor": 1.15,              "maxLaunchDelaySeconds": 3600,              "container": {                "type": "DOCKER",                "volumes": [                  {                    "containerPath": "/docker_storage",                    "hostPath": "/hdd/tools/docker/registry",                    "mode": "RW"                  }                ],                "docker": {                  "image": "registry",                  "network": "BRIDGE",                  "portMappings": [                    {                      "containerPort": 5000,                      "hostPort": 0,                      "servicePort": 5000,                      "protocol": "tcp"                    }                  ],                  "privileged": false,                  "parameters": [],                  "forcePullImage": false                }              },              "healthChecks": [],              "dependencies": [],              "upgradeStrategy": {                "minimumHealthCapacity": 1,                "maximumOverCapacity": 1              },              "version": "2015-08-19T21:26:47.616Z",              "versionInfo": {                "lastScalingAt": "2015-08-19T21:26:47.616Z",                "lastConfigChangeAt": "2015-08-19T21:00:54.621Z"              }            }          ],          "groups": [],          "dependencies": [],          "version": "2015-09-17T10:38:20.875Z"        }      ],      "dependencies": [],      "version": "2015-09-17T10:38:20.875Z"    }  ],  "dependencies": [],  "version": "2015-09-17T10:38:20.875Z"}'
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: NONE
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2Groups1
+        x-testDescription: >-
+          Change parameters of a deployed application group. The new group parameters get applied.
+
+
+          * Changes to application parameters will result in a restart of this application.
+
+          * A new application added to the group will be started.
+
+          * An existing application removed from the group will be stopped.
+
+
+          If there are no changes to the application definition, no restart is triggered. During restart marathon keeps track, that the configured amount of minimal running instances are _always_ available.
+
+          This method allows 2 special modes for the update operation>
+
+
+          * Provide only the `version` field in the group definition. This will rollback the group to that given version
+
+          * Provide only the `scaleBy` field will scale all transitive applications instance counts by the given factor.
+
+
+          When one of version or scaleBy are set, nothing else than a version change or transitive instance count scaling will be applied. If both version and scaleBy are set, only a version rollback will be performed â the scaleBy value will not be applied.
+
+          A deployment can run forever. This is the case, when the new application has a problem and does not become healthy. In this case, human interaction is needed with 2 possible choices
+
+
+          * Rollback to an existing older version
+
+          * Update with a newer version of the group which does not have the problems of the old one.
+
+
+          Since the deployment of the group can take a considerable amount of time, this endpoint returns immediately with a version. The failure or success of the action is signalled via event. There is a group_change_success and group_change_failed with the given version.
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+    post:
+      description: Create and start a new application group. Application groups can contain other application groups.
+      tags:
+      - v2
+      operationId: V2Groups1
+      produces:
+      - application/json
+      parameters:
+      - name: force
+        in: query
+        required: false
+        default: false
+        type: boolean
+        description: >-
+          Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
+
+          Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/Group'
+      responses:
+        200:
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
+          schema:
+            type: string
+        400:
+          description: The group definition provided in the body is not valid.
+          schema:
+            type: string
+        409:
+          description: There is an already deployed group with this name
+          schema:
+            type: string
+        422:
+          description: The entity send can not be preocessed, since there are validation errors
+          schema:
+            type: string
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: POST
+          uri: /v2/groups/?force=false
+          headers:
+            Content-Type: application/json
+          body: '{  "id": "/",  "apps": [],  "groups": [    {      "id": "/tools",      "apps": [        {          "id": "/tools/oauth-server",          "instances": 2,          "cpus": 1,          "mem": 1024,          "disk": 0,          "constraints": [            [              "hostname",              "UNIQUE"            ]          ],          "uris": [],          "storeUrls": [],          "ports": [            1980          ],          "requirePorts": false,          "backoffSeconds": 1,          "backoffFactor": 1.15,          "maxLaunchDelaySeconds": 3600,          "container": {            "type": "DOCKER",            "volumes": [],            "docker": {              "image": "docker-registry/oauth_server:6d7d463cb8b1517002080a81cf23f9cf7b7fc774",              "network": "HOST",              "privileged": false,              "parameters": [],              "forcePullImage": false            }          },          "healthChecks": [            {              "path": "/",              "protocol": "HTTP",              "portIndex": 0,              "gracePeriodSeconds": 300,              "intervalSeconds": 20,              "timeoutSeconds": 20,              "maxConsecutiveFailures": 3,              "ignoreHttp1xx": false            }          ],          "dependencies": [],          "upgradeStrategy": {            "minimumHealthCapacity": 0.5,            "maximumOverCapacity": 0          },          "version": "2015-09-28T19:47:37.681Z",          "versionInfo": {            "lastScalingAt": "2015-09-28T19:47:37.681Z",            "lastConfigChangeAt": "2015-09-28T19:47:37.681Z"          }        },        {          "id": "/tools/datadog-agent",          "instances": 5,          "cpus": 1,          "mem": 512,          "disk": 0,          "executor": "",          "constraints": [            [              "hostname",              "UNIQUE"            ]          ],          "uris": [],          "storeUrls": [],          "ports": [            10018          ],          "requirePorts": false,          "backoffSeconds": 1,          "backoffFactor": 1.15,          "maxLaunchDelaySeconds": 3600,          "container": {            "type": "DOCKER",            "volumes": [              {                "containerPath": "/var/run/docker.sock",                "hostPath": "/var/run/docker.sock",                "mode": "RW"              },              {                "containerPath": "/host/proc/mounts",                "hostPath": "/proc/mounts",                "mode": "RO"              },              {                "containerPath": "/host/sys/fs/cgroup",                "hostPath": "/sys/fs/cgroup/",                "mode": "RO"              }            ],            "docker": {              "image": "datadog/docker-dd-agent:latest",              "network": "HOST",              "privileged": true,              "parameters": [],              "forcePullImage": false            }          },          "healthChecks": [],          "dependencies": [],          "upgradeStrategy": {            "minimumHealthCapacity": 0.5,            "maximumOverCapacity": 0          },          "version": "2015-08-26T22:33:24.225Z",          "versionInfo": {            "lastScalingAt": "2015-08-26T22:33:24.225Z",            "lastConfigChangeAt": "2015-05-19T13:59:18.899Z"          }        }      ],      "groups": [        {          "id": "/tools/log",          "apps": [],          "groups": [],          "dependencies": [],          "version": "2015-09-17T10:38:20.875Z"        },        {          "id": "/tools/docker",          "apps": [            {              "id": "/tools/docker/registry",              "instances": 1,              "cpus": 0.5,              "mem": 4096,              "disk": 0,              "executor": "",              "constraints": [],              "uris": [],              "storeUrls": [],              "ports": [                5000              ],              "requirePorts": false,              "backoffSeconds": 1,              "backoffFactor": 1.15,              "maxLaunchDelaySeconds": 3600,              "container": {                "type": "DOCKER",                "volumes": [                  {                    "containerPath": "/docker_storage",                    "hostPath": "/hdd/tools/docker/registry",                    "mode": "RW"                  }                ],                "docker": {                  "image": "registry",                  "network": "BRIDGE",                  "portMappings": [                    {                      "containerPort": 5000,                      "hostPort": 0,                      "servicePort": 5000,                      "protocol": "tcp"                    }                  ],                  "privileged": false,                  "parameters": [],                  "forcePullImage": false                }              },              "healthChecks": [],              "dependencies": [],              "upgradeStrategy": {                "minimumHealthCapacity": 1,                "maximumOverCapacity": 1              },              "version": "2015-08-19T21:26:47.616Z",              "versionInfo": {                "lastScalingAt": "2015-08-19T21:26:47.616Z",                "lastConfigChangeAt": "2015-08-19T21:00:54.621Z"              }            }          ],          "groups": [],          "dependencies": [],          "version": "2015-09-17T10:38:20.875Z"        }      ],      "dependencies": [],      "version": "2015-09-17T10:38:20.875Z"    }  ],  "dependencies": [],  "version": "2015-09-17T10:38:20.875Z"}'
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: NONE
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2Groups1
+        x-testDescription: Create and start a new application group. Application groups can contain other application groups.
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+    delete:
+      description: Destroy a group. All data about that group and all associated applications will be deleted. The failure or success of the action is signalled via events. There is a group_change_success and group_change_failed with the given version.
+      tags:
+      - v2
+      operationId: V2Groups2
+      produces:
+      - application/json
+      parameters:
+      - name: force
+        in: query
+        required: false
+        default: false
         type: boolean
         description: >-
           Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
@@ -842,23 +1796,46 @@ paths:
           Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
       responses:
         200:
-          description: Success.
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
+          schema:
+            type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
         409:
           description: There is an already running deployment, that affects this application. To override this deployment, use the force=true flag
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: DELETE
+          uri: /v2/groups/?force=false
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: NONE
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2Groups1
+        x-testDescription: Destroy a group. All data about that group and all associated applications will be deleted. The failure or success of the action is signalled via events. There is a group_change_success and group_change_failed with the given version.
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /groups/{group_id}/versions:
+  /v2/groups/{group_id}//versions:
     get:
       description: List all versions the group with the specified path.
       tags:
-      - groups
+      - v2
       operationId: V2GroupsVersionsByGroupId
       produces:
       - application/json
@@ -866,37 +1843,42 @@ paths:
       - name: group_id
         in: path
         required: true
-        x-is-map: false
         type: string
       responses:
         200:
-          description: List all versions the group with the specified path.
+          description: List all available versions of that group.
           schema:
-            type: array
-            items:
-              type: string
+            type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /groups/{group_id}:
+  /v2/groups/{group_id}/:
     get:
       description: Get the group with all applications and all transitive child groups.
       tags:
-      - groups
+      - v2
       operationId: V2GroupsByGroupId
       produces:
       - application/json
       parameters:
+      - name: group_id
+        in: path
+        required: true
+        type: string
       - name: embed
         in: query
         required: false
-        x-is-map: false
         enum:
         - Enum_group.groups
         - Enum_group.apps
@@ -925,68 +1907,108 @@ paths:
           - <code>group.apps.lastTaskFailure</code> embeds the lastTaskFailure for the application if there is one.
 
           - <code>group.apps.taskStats</code> exposes task statistics in the JSON.
-      - name: group_id
-        in: path
-        required: true
-        x-is-map: false
-        type: string
       responses:
         200:
-          description: Gives the group with all applications and all transitive child groups.
+          description: The group with all transitive dependencies.
           schema:
             $ref: '#/definitions/Group'
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
     put:
-      description: "Change parameters of a deployed application group. The new group parameters get applied.\n\n* Changes to application parameters will result in a restart of this application.\n* A new application added to the group will be started.\n* An existing application removed from the group will be stopped.\n\nIf there are no changes to the application definition, no restart is triggered. During restart marathon keeps track, that the configured amount of minimal running instances are _always_ available.\nThis method allows 2 special modes for the update operation>\n\n* Provide only the `version` field in the group definition. This will rollback the group to that given version\n* Provide only the `scaleBy` field will scale all transitive applications instance counts by the given factor.\n\nWhen one of version or scaleBy are set, nothing else than a version change or transitive instance count scaling will be applied. If both version and scaleBy are set, only a version rollback will be performed – the scaleBy value will not be applied.\nA deployment can run forever. This is the case, when the new application has a problem and does not become healthy. In this case, human interaction is needed with 2 possible choices\n\n* Rollback to an existing older version\n* Update with a newer version of the group which does not have the problems of the old one.\n\nSince the deployment of the group can take a considerable amount of time, this endpoint returns immediately with a version. The failure or success of the action is signalled via event. There is a group_change_success and group_change_failed with the given version."
+      description: >-
+        Change parameters of a deployed application group. The new group parameters get applied.
+
+
+        * Changes to application parameters will result in a restart of this application.
+
+        * A new application added to the group will be started.
+
+        * An existing application removed from the group will be stopped.
+
+
+        If there are no changes to the application definition, no restart is triggered. During restart marathon keeps track, that the configured amount of minimal running instances are _always_ available.
+
+        This method allows 2 special modes for the update operation>
+
+
+        * Provide only the `version` field in the group definition. This will rollback the group to that given version
+
+        * Provide only the `scaleBy` field will scale all transitive applications instance counts by the given factor.
+
+
+        When one of version or scaleBy are set, nothing else than a version change or transitive instance count scaling will be applied. If both version and scaleBy are set, only a version rollback will be performed â the scaleBy value will not be applied.
+
+        A deployment can run forever. This is the case, when the new application has a problem and does not become healthy. In this case, human interaction is needed with 2 possible choices
+
+
+        * Rollback to an existing older version
+
+        * Update with a newer version of the group which does not have the problems of the old one.
+
+
+        Since the deployment of the group can take a considerable amount of time, this endpoint returns immediately with a version. The failure or success of the action is signalled via event. There is a group_change_success and group_change_failed with the given version.
       tags:
-      - groups
-      operationId: V2GroupsByGroupId1
+      - v2
+      operationId: V2GroupsByGroupId3
       produces:
       - application/json
       parameters:
+      - name: group_id
+        in: path
+        required: true
+        type: string
       - name: force
         in: query
         required: false
-        x-is-map: false
+        default: false
         type: boolean
         description: >-
           Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
 
           Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
-      - name: group_id
-        in: path
-        required: true
-        x-is-map: false
-        type: string
       - name: body
         in: body
         required: true
-        x-is-map: false
         schema:
           $ref: '#/definitions/Group'
       responses:
         200:
-          description: Success
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
           schema:
-            $ref: '#/definitions/V2AppsRestartresponse'
+            type: string
         400:
           description: The group definition provided in the body is not valid.
+          schema:
+            type: string
         422:
           description: The entity send can not be preocessed, since there are validation errors
+          schema:
+            type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
         409:
           description: There is an already running deployment, that affects this application. To override this deployment, use the force=true flag
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -995,46 +2017,55 @@ paths:
     post:
       description: Create and start a new application group. Application groups can contain other application groups.
       tags:
-      - groups
-      operationId: V2GroupsByGroupId2
+      - v2
+      operationId: V2GroupsByGroupId1
       produces:
       - application/json
       parameters:
+      - name: group_id
+        in: path
+        required: true
+        type: string
       - name: force
         in: query
         required: false
-        x-is-map: false
+        default: false
         type: boolean
         description: >-
           Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
 
           Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
-      - name: group_id
-        in: path
-        required: true
-        x-is-map: false
-        type: string
       - name: body
         in: body
         required: true
-        x-is-map: false
         schema:
           $ref: '#/definitions/Group'
       responses:
         200:
-          description: Success
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
           schema:
-            $ref: '#/definitions/V2AppsRestartresponse'
+            type: string
         400:
           description: The group definition provided in the body is not valid.
+          schema:
+            type: string
         409:
           description: There is an already deployed group with this name
+          schema:
+            type: string
         422:
           description: The entity send can not be preocessed, since there are validation errors
+          schema:
+            type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -1043,64 +2074,70 @@ paths:
     delete:
       description: Destroy a group. All data about that group and all associated applications will be deleted. The failure or success of the action is signalled via events. There is a group_change_success and group_change_failed with the given version.
       tags:
-      - groups
-      operationId: V2GroupsByGroupId3
+      - v2
+      operationId: V2GroupsByGroupId2
       produces:
       - application/json
       parameters:
+      - name: group_id
+        in: path
+        required: true
+        type: string
       - name: force
         in: query
         required: false
-        x-is-map: false
+        default: false
         type: boolean
         description: >-
           Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
 
           Caution&#58; setting force=true will cancel the current deployment. This paramter should be used only, if the current deployment is unsuccessful!
-      - name: group_id
-        in: path
-        required: true
-        x-is-map: false
-        type: string
       responses:
         200:
-          description: Success.
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
+          schema:
+            type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
         409:
           description: There is an already running deployment, that affects this application. To override this deployment, use the force=true flag
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /tasks/delete:
+  /v2/tasks/delete:
     post:
       description: Kill a list of running tasks.
       tags:
-      - tasks
+      - v2
       operationId: V2TasksDelete
       produces:
       - application/json
       parameters:
       - name: scale
         in: query
-        required: false
-        x-is-map: false
+        required: true
         type: boolean
         description: If `scale=true` is specified, then the related application is scaled down by the number of killed tasks. Only possible if `wipe=false` or not specified.
       - name: wipe
         in: query
-        required: false
-        x-is-map: false
+        required: true
         type: boolean
         description: If `wipe=true` is specified and the app uses local persistent volumes, associated dynamic reservations will be unreserved, and persistent volumes will be destroyed. Only possible if `scale=false` or not specified.
       - name: force
         in: query
         required: false
-        x-is-map: false
+        default: false
         type: boolean
         description: >-
           Only one deployment can be applied to one application at the same time. If the existing deployment should be canceled by this change, you can set force=true.
@@ -1109,40 +2146,65 @@ paths:
       - name: body
         in: body
         required: true
-        x-is-map: false
         schema:
-          $ref: '#/definitions/V2TasksDeleterequest'
+          type: string
       responses:
         200:
-          description: Success.
+          description: A deployment is started which has a unique deployment identifier. The related deployment can be fetched from the /v2/deployments endpoint. If the deployement is gone from the list of deployments, it means that it is finished. As long as the deployment runs, the effect of that change operation is visible only partially.
           schema:
-            $ref: '#/definitions/V2AppsTasksresponse'
+            type: string
         400:
           description: There are unknown task ids, that can not be killed.
+          schema:
+            type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
         409:
           description: There is an already running deployment, that affects this application. To override this deployment, use the force=true flag
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: POST
+          uri: /v2/tasks/delete?scale=false&wipe=false&force=false
+          headers:
+            Content-Type: application/json
+          body: '{ "ids": [ "task1", "task2" ] }'
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: RAW
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+          body: '{  "tasks": [    {      "id": "frontend-foosball.083be411-5d1f-11e5-88f7-56b91e7a505b",      "host": "srv4.example.com",      "ports": [        31292      ],      "startedAt": "2015-09-17T09:32:42.598Z",      "stagedAt": "2015-09-17T09:32:36.822Z",      "version": "2015-09-17T09:32:36.583Z",      "slaveId": "20150707-153709-201330860-5050-12052-S0",      "appId": "/frontend-foosball",      "servicePorts": [        10019      ]    },    {      "id": "tools_docker_registry.002b4d28-46b9-11e5-b731-525400cce7ed",      "host": "srv2.example.com",      "ports": [        31721      ],      "startedAt": "2015-08-19T21:26:50.864Z",      "stagedAt": "2015-08-19T21:26:49.04Z",      "version": "2015-08-19T21:26:47.616Z",      "slaveId": null,      "appId": "/tools/docker/registry",      "servicePorts": [        5000      ]    }  ]}'
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2TasksDelete1
+        x-testDescription: Kill a list of running tasks.
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /tasks:
+  /v2/tasks:
     get:
       description: List all running tasks.
       tags:
-      - tasks
+      - v2
       operationId: V2Tasks
       produces:
       - application/json
       parameters:
       - name: status
         in: query
-        required: false
-        x-is-map: false
+        required: true
         enum:
         - running
         - staging
@@ -1150,39 +2212,43 @@ paths:
         description: Filter the list of tasks by status
       responses:
         200:
-          description: Lists tasks.
+          description: The list of all tasks disregarding their status, or a list of tasks matching the specified status filter.
           schema:
-            $ref: '#/definitions/V2AppsTasksresponse'
+            type: string
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /artifacts/{path}:
+  /v2/artifacts/{path}:
     get:
       description: Download an artifact from the artifact store. The path is the relative path in the artifact store.
       tags:
-      - artifacts
-      operationId: V2ArtifactsByPath3
+      - v2
+      operationId: V2ArtifactsByPath
       produces:
       - application/json
       parameters:
       - name: path
         in: path
         required: true
-        x-is-map: false
         type: string
       responses:
         200:
-          description: Success
-          schema:
-            type: string
+          description: The response contains the content of the artifact with the given id. The content type depends on the content of the artifact.
         404:
           description: There is no artifact in the artifact store with this path.
+          schema: {}
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -1191,28 +2257,25 @@ paths:
     put:
       description: Upload an artifact to the artifact store. A multipart form upload request has to be performed. The form parameter name has to be ```file```. The path used to store the file is taken from the url path. The response holds the URL of the artifact in the artifact store in the Location Header.
       tags:
-      - artifacts
-      operationId: V2ArtifactsByPath
+      - v2
+      operationId: V2ArtifactsByPath3
       produces:
       - application/json
       parameters:
       - name: path
         in: path
         required: true
-        x-is-map: false
         type: string
       - name: file
-        in: formData
-        required: false
-        x-is-map: false
-        type: file
-        format: file
+        in: query
+        required: true
+        type: string
+        format: binary
         description: The file to upload
       responses:
         200:
-          description: Success
-          schema:
-            type: string
+          description: The file has been updated. No body is sent.
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -1221,7 +2284,7 @@ paths:
     post:
       description: Upload an artifact to the artifact store. A multipart form upload request has to be performed. The form parameter name has to be ```file```. The path used to store the file is taken from the url path. The response holds the URL of the artifact in the artifact store in the Location Header.
       tags:
-      - artifacts
+      - v2
       operationId: V2ArtifactsByPath1
       produces:
       - application/json
@@ -1229,20 +2292,17 @@ paths:
       - name: path
         in: path
         required: true
-        x-is-map: false
         type: string
       - name: file
-        in: formData
-        required: false
-        x-is-map: false
-        type: file
-        format: file
+        in: query
+        required: true
+        type: string
+        format: binary
         description: The file to upload
       responses:
         200:
-          description: Success.
-          schema:
-            type: string
+          description: The file has been updated. No body is sent.
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -1251,7 +2311,7 @@ paths:
     delete:
       description: Delete an artifact from the artifact store. The path is the relative path in the artifact store.
       tags:
-      - artifacts
+      - v2
       operationId: V2ArtifactsByPath2
       produces:
       - application/json
@@ -1259,45 +2319,44 @@ paths:
       - name: path
         in: path
         required: true
-        x-is-map: false
         type: string
       responses:
         200:
-          description: Success
+          description: The artifact with this path has been deleted.
         404:
           description: There is no artifact in the artifact store with this path.
+          schema: {}
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /artifacts:
+  /v2/artifacts:
     post:
       description: Upload an artifact to the artifact store. A multipart form upload request has to be performed. The form parameter name has to be ```file```. The filename used in the artifact store, is the same as given by the form parameter. The response holds the URL of the artifact in the artifact store in the Location Header.
       tags:
-      - artifacts
+      - v2
       operationId: V2Artifacts
       produces:
       - application/json
       parameters:
       - name: file
-        in: formData
-        required: false
-        x-is-map: false
-        type: file
-        format: file
+        in: query
+        required: true
+        type: string
+        format: binary
         description: The file to upload
       responses:
         200:
-          description: Success.
-          schema:
-            type: string
+          description: The file has been updated. No body is sent.
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /events:
+  /v2/events:
     get:
       description: >-
         Attach to the marathon event stream.
@@ -1308,37 +2367,60 @@ paths:
 
         Note for ApiConsole&#58; this function will not yield the expected result from inside ApiConsole.
       tags:
-      - events
+      - v2
       operationId: V2Events
       produces:
       - application/json
-      parameters: []
+      parameters:
+      - name: event_type
+        in: query
+        required: false
+        type: string
+        description: Specify subscribed event types. You can specify this parameter multiple times with different values.
       responses:
         200:
-          description: Success.
+          description: the list of all tasks waiting to be scheduled.
           schema:
-            type: string
+            type: object
         405:
           description: A request has been made without the correct Accept Header
+          schema: {}
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /eventSubscriptions:
+  /v2/eventSubscriptions:
     get:
       description: List all event subscriber callback URLs. _NOTE To activate this endpoint, you need to startup a Marathon instance with `--event_subscriber http_callback`_
       tags:
-      - events
+      - v2
       operationId: V2EventSubscriptions
       produces:
       - application/json
       parameters: []
       responses:
         200:
-          description: Success.
+          description: Return the list of all subscription endpoints
           schema:
-            $ref: '#/definitions/V2EventSubscriptionsresponse'
+            type: string
+      x-unitTests:
+      - request:
+          method: GET
+          uri: /v2/eventSubscriptions
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: RAW
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+          body: '{    "callbackUrls": [        "http://server123:9090/callback",        "http://server234:9191/callback"    ]}'
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2EventSubscriptions1
+        x-testDescription: List all event subscriber callback URLs. _NOTE To activate this endpoint, you need to startup a Marathon instance with `--event_subscriber http_callback`_
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -1347,22 +2429,22 @@ paths:
     post:
       description: Subscribe to the event callback mechanism with the specified callback URL.
       tags:
-      - events
+      - v2
       operationId: V2EventSubscriptions1
       produces:
       - application/json
       parameters:
       - name: callbackUrl
         in: query
-        required: false
-        x-is-map: false
+        required: true
         type: string
-        description: The URL to an endpoint that is able to handle post requests for every event that is send.
+        description: The URL to an endpoint that is able to handle post requests for every event that is sent.
       responses:
         200:
-          description: Success
+          description: ''
           schema:
-            $ref: '#/definitions/V2EventSubscriptionsresponse204'
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -1371,60 +2453,96 @@ paths:
     delete:
       description: Unregister a callback URL from the event subscribers list.
       tags:
-      - events
+      - v2
       operationId: V2EventSubscriptions2
       produces:
       - application/json
       parameters:
       - name: callbackUrl
         in: query
-        required: false
-        x-is-map: false
+        required: true
         type: string
-        description: The URL to an endpoint that is able to handle post requests for every event that is send.
+        description: The URL to an endpoint that is able to handle post requests for every event that is sent.
       responses:
         200:
-          description: Success.
+          description: ''
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /info:
+  /v2/info:
     get:
       description: Get info about the Marathon Instance
       tags:
-      - info
+      - v2
       operationId: V2Info
       produces:
       - application/json
       parameters: []
       responses:
         200:
-          description: Gives info.
+          description: General configuration and runtime information about this Marathon instance.
           schema:
-            $ref: '#/definitions/V2Inforesponse'
+            type: string
+      x-unitTests:
+      - request:
+          method: GET
+          uri: /v2/info
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: RAW
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+          body: '{  "name": "marathon",  "version": "0.13.0-SNAPSHOT",  "elected": true,  "leader": "wrk.fritz.box:8080",  "frameworkId": "80ba2050-bf0f-4472-a2f7-2636c4f7b8c8-0000",  "marathon_config": {    "master": "127.0.0.1:5050",    "failover_timeout": 604800,    "framework_name": "marathon",    "ha": true,    "checkpoint": true,    "local_port_min": 10000,    "local_port_max": 20000,    "executor": "//cmd",    "hostname": "wrk.fritz.box",    "webui_url": null,    "mesos_role": null,    "task_launch_timeout": 300000,    "reconciliation_initial_delay": 15000,    "reconciliation_interval": 300000,    "mesos_user": "matthias",    "leader_proxy_connection_timeout_ms": 5000,    "leader_proxy_read_timeout_ms": 10000,    "mesos_leader_ui_url": null  },  "zookeeper_config": {    "zk": "zk://localhost:2181/marathon",    "zk_timeout": 10000,    "zk_session_timeout": 1800000,    "zk_max_versions": 25  },  "event_subscriber": null,  "http_config": {    "assets_path": null,    "http_port": 8080,    "https_port": 8443  }}'
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2Info1
+        x-testDescription: Get info about the Marathon Instance
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /leader:
+  /v2/leader:
     get:
       description: Returns the current leader.
       tags:
-      - leader
+      - v2
       operationId: V2Leader
       produces:
       - application/json
       parameters: []
       responses:
         200:
-          description: Displays current leader.
+          description: The host and port of the current leading master.
           schema:
-            $ref: '#/definitions/V2Leaderresponse'
+            type: string
         404:
           description: If there is no current leader.
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: GET
+          uri: /v2/leader
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: RAW
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+          body: '{    "leader": "marathon.globalcorp.com:8080"}'
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2Leader1
+        x-testDescription: Returns the current leader.
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -1433,26 +2551,46 @@ paths:
     delete:
       description: Causes the current leader to abdicate, triggering a new election.
       tags:
-      - leader
+      - v2
       operationId: V2Leader1
       produces:
       - application/json
       parameters: []
       responses:
         200:
-          description: Success.
+          description: The abdication message from the current leader.
+          schema:
+            type: string
         404:
           description: If there is no current leader.
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: DELETE
+          uri: /v2/leader
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: RAW
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+          body: '{    "message": "Leadership abdicated"}'
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2Leader1
+        x-testDescription: Causes the current leader to abdicate, triggering a new election.
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /plugins/{plugin_id}/{path}:
+  /v2/plugins/{plugin_id}/{path}:
     get:
       description: Get request is handled by the plugin.
       tags:
-      - plugins
+      - v2
       operationId: V2PluginsByPluginIdAndPath
       produces:
       - application/json
@@ -1460,16 +2598,15 @@ paths:
       - name: plugin_id
         in: path
         required: true
-        x-is-map: false
         type: string
       - name: path
         in: path
         required: true
-        x-is-map: false
         type: string
       responses:
         200:
-          description: Success.
+          description: ''
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -1478,24 +2615,23 @@ paths:
     put:
       description: Put request is handled by the plugin.
       tags:
-      - plugins
-      operationId: V2PluginsByPluginIdAndPath1
+      - v2
+      operationId: V2PluginsByPluginIdAndPath3
       produces:
       - application/json
       parameters:
       - name: plugin_id
         in: path
         required: true
-        x-is-map: false
         type: string
       - name: path
         in: path
         required: true
-        x-is-map: false
         type: string
       responses:
         200:
-          description: Success.
+          description: ''
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -1504,24 +2640,23 @@ paths:
     post:
       description: Post request is handled by the plugin.
       tags:
-      - plugins
-      operationId: V2PluginsByPluginIdAndPath2
+      - v2
+      operationId: V2PluginsByPluginIdAndPath1
       produces:
       - application/json
       parameters:
       - name: plugin_id
         in: path
         required: true
-        x-is-map: false
         type: string
       - name: path
         in: path
         required: true
-        x-is-map: false
         type: string
       responses:
         200:
-          description: Success.
+          description: ''
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -1530,53 +2665,149 @@ paths:
     delete:
       description: Delete request is handled by the plugin.
       tags:
-      - plugins
-      operationId: V2PluginsByPluginIdAndPath3
+      - v2
+      operationId: V2PluginsByPluginIdAndPath2
       produces:
       - application/json
       parameters:
       - name: plugin_id
         in: path
         required: true
-        x-is-map: false
         type: string
       - name: path
         in: path
         required: true
-        x-is-map: false
         type: string
       responses:
         200:
-          description: Success
+          description: ''
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /plugins:
+  /v2/plugins:
     get:
       description: Returns the list of all loaded plugins
       tags:
-      - plugins
+      - v2
       operationId: V2Plugins
       produces:
       - application/json
       parameters: []
       responses:
         200:
-          description: Lists all loaded plugins.
+          description: The list of all loaded plugins
           schema:
-            $ref: '#/definitions/V2Pluginsresponse'
+            type: string
+      x-unitTests:
+      - request:
+          method: GET
+          uri: /v2/plugins
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: RAW
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+          body: '{    "plugins": [        {            "id": "webjar",            "implementation": "mesosphere.marathon.example.plugin.http.WebJarHandler",            "info": {                "version": "1.2.3",                "array": [ 1, 2, 3, 4, 5, 6 ],                "test": true            },            "plugin": "mesosphere.marathon.plugin.http.HttpRequestHandler",            "tags": [ "webjar", "test" ]        }    ]}'
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2Plugins1
+        x-testDescription: Returns the list of all loaded plugins
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-  /queue/{app_id}/delay:
-    delete:
-      description: If an application fails too often in a specified amount of time (according to the application definition), the task launch will be delayed. This delay can be removed by calling this endpoint. The effect is, that the tasks of this application will be launched immediately.
+  /v2/queue/:
+    get:
+      description: >
+        List all the tasks queued up or waiting to be scheduled.
+
+        This is mainly used for troubleshooting and occurs when scaling
+
+        changes are requested and the volume of scaling changes out paces the ability to schedule those tasks.
+
+        In addition to the application in the queue, you see also the task count that needs to be started.
+
+        If the task has a rate limit, then a delay to the start gets applied.
+
+        You can see this delay for every application with the seconds to wait before the next launch will be tried.
       tags:
-      - queue
+      - v2
+      operationId: V2Queue
+      produces:
+      - application/json
+      parameters:
+      - name: embed
+        in: query
+        required: false
+        type: string
+        description: >-
+          Embeds nested resources that match the supplied path. You can specify this parameter multiple times with different values.
+
+          - <code>lastUnusedOffers</code> embed all unused offers for every application.
+      responses:
+        200:
+          description: >
+            The list of all tasks waiting to be scheduled.
+          schema:
+            $ref: '#/definitions/Queue'
+        401:
+          description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
+        403:
+          description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests:
+      - request:
+          method: GET
+          uri: /v2/queue/
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: RAW
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+          body: '{  "queue": [    {      "app": {        "id": "/tools/datadog-agent",        "instances": 5,        "cpus": 1.0,        "mem": 512.0,        "disk": 0.0,        "constraints": [          [            "hostname",            "UNIQUE"          ]        ],        "ports": [          10018        ],        "requirePorts": false,        "backoffSeconds": 1,        "backoffFactor": 1.15,        "maxLaunchDelaySeconds": 3600,        "container": {          "type": "DOCKER",          "docker": {            "image": "datadog/docker-dd-agent:latest",            "network": "HOST",            "privileged": true,            "forcePullImage": false          }        },        "upgradeStrategy": {          "minimumHealthCapacity": 0.5,          "maximumOverCapacity": 0.0        },        "version": "2015-08-26T22:33:24.225Z",        "versionInfo": {          "lastScalingAt": "2015-08-26T22:33:24.225Z",          "lastConfigChangeAt": "2015-05-19T13:59:18.899Z"        }      },      "count": 1,      "delay": {        "timeLeftSeconds": 0,        "overdue": true      },      "since": "2016-02-28T16:41:41.09Z",      "processedOffersSummary": {        "processedOffersCount": 123,        "unusedOffersCount": 0      }    },    {      "app": {        "id": "/foo",        "user": "root",        "env": {          "MASTER": "zk://172.16.0.12:2181,172.16.0.13:2181,172.16.0.14:2181/mesos"        },        "instances": 1,        "cpus": 0.5,        "mem": 128.0,        "disk": 0.0,        "executor": "//cmd",        "constraints": [          [            "hostname",            "UNIQUE"          ]        ],        "uris": [          "http://www.mesosphere.io/index.html"        ],        "ports": [          10010        ],        "requirePorts": false,        "backoffSeconds": 1,        "backoffFactor": 1.15,        "maxLaunchDelaySeconds": 3600,        "container": {          "type": "DOCKER",          "docker": {            "image": "thomasr/dispatch",            "network": "HOST",            "privileged": false,            "forcePullImage": false          }        },        "upgradeStrategy": {          "minimumHealthCapacity": 1.0,          "maximumOverCapacity": 1.0        },        "version": "2015-09-30T09:09:17.614Z",        "versionInfo": {          "lastScalingAt": "2015-09-30T09:09:17.614Z",          "lastConfigChangeAt": "2015-09-30T09:09:17.614Z"        }      },      "count": 2,      "delay": {        "timeLeftSeconds": 0,        "overdue": true      },      "since": "2016-02-28T16:41:41.09Z",      "processedOffersSummary": {        "processedOffersCount": 123,        "unusedOffersCount": 123,        "lastUnusedOfferAt": "2016-02-28T16:41:41.09Z",        "lastUsedOfferAt": "2016-02-28T16:41:41.09Z",        "rejectSummaryLastOffers": [          {            "reason": "UnfulfilledRole",            "declined": 0,            "processed": 123          },          {            "reason": "UnfulfilledConstraint",            "declined": 0,            "processed": 123          },          {            "reason": "NoCorrespondingReservationFound",            "declined": 0,            "processed": 123          },          {            "reason": "InsufficientCpus",            "declined": 75,            "processed": 123          },          {            "reason": "InsufficientMemory",            "declined": 15,            "processed": 48          },          {            "reason": "InsufficientDisk",            "declined": 10,            "processed": 33          },          {            "reason": "InsufficientGpus",            "declined": 0,            "processed": 23          },          {            "reason": "InsufficientGpus",            "declined": 0,            "processed": 23          }        ],        "rejectSummaryLaunchAttempt": [          {            "reason": "UnfulfilledRole",            "declined": 0,            "processed": 246          },          {            "reason": "UnfulfilledConstraint",            "declined": 0,            "processed": 246          },          {            "reason": "NoCorrespondingReservationFound",            "declined": 0,            "processed": 246          },          {            "reason": "InsufficientCpus",            "declined": 150,            "processed": 246          },          {            "reason": "InsufficientMemory",            "declined": 30,            "processed": 96          },          {            "reason": "InsufficientDisk",            "declined": 20,            "processed": 66          },          {            "reason": "InsufficientGpus",            "declined": 0,            "processed": 46          },          {            "reason": "InsufficientGpus",            "declined": 0,            "processed": 46          }        ]      },      "lastUnusedOffers": [        {          "offer": {            "id": "offer_123",            "agentId": "slave_123",            "hostname": "1.2.3.4",            "resources": [              {                "name": "cpus",                "scalar": 23,                "ranges": [                  {                    "begin": 1,                    "end": 5                  }                ],                "set": [                  "a",                  "b"                ],                "role": "*"              }            ],            "attributes": [              {                "name": "foo",                "scalar": 23,                "ranges": [                  {                    "begin": 1,                    "end": 5                  }                ],                "set": [                  "a",                  "b"                ]              }            ]          },          "timestamp": "2016-02-28T16:41:41.09Z",          "reason": [            "InsufficientMemory"          ]        }      ]    }  ]}'
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: V2Queue1
+        x-testDescription: >
+          List all the tasks queued up or waiting to be scheduled.
+
+          This is mainly used for troubleshooting and occurs when scaling
+
+          changes are requested and the volume of scaling changes out paces the ability to schedule those tasks.
+
+          In addition to the application in the queue, you see also the task count that needs to be started.
+
+          If the task has a rate limit, then a delay to the start gets applied.
+
+          You can see this delay for every application with the seconds to wait before the next launch will be tried.
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  /v2/queue/{app_id}/delay:
+    delete:
+      description: >
+        If an application fails too often in a specified amount of time (according to the application definition),
+
+        the task launch will be delayed.
+
+        This delay can be removed by calling this endpoint.
+
+        The effect is, that the tasks of this application will be launched immediately.
+      tags:
+      - v2
       operationId: V2QueueDelayByAppId
       produces:
       - application/json
@@ -1584,41 +2815,22 @@ paths:
       - name: app_id
         in: path
         required: true
-        x-is-map: false
         type: string
       responses:
         200:
-          description: Success.
+          description: the delay is reset and no body is returned
         404:
           description: there is no delay for the given application with id `app_id`
-      x-operation-settings:
-        CollectParameters: false
-        AllowDynamicQueryParameters: false
-        AllowDynamicFormParameters: false
-        IsMultiContentStreaming: false
-  /queue:
-    get:
-      description: >-
-        List all the tasks queued up or waiting to be scheduled. This is mainly used for troubleshooting and occurs when scaling changes are requested and the volume of scaling changes out paces the ability to schedule those tasks.
-
-        In addition to the application in the queue, you see also the task count that needs to be started.
-
-        If the task has a rate limit, then a delay to the start gets applied. You can see this delay for every application with the seconds to wait before the next launch will be tried.
-      tags:
-      - queue
-      operationId: V2Queue
-      produces:
-      - application/json
-      parameters: []
-      responses:
-        200:
-          description: Lists queued tasks.
-          schema:
-            $ref: '#/definitions/V2Queueresponse'
+          schema: {}
         401:
           description: Unauthorized. Authentication is enabled and you did not provide enough or wrong information to authenticate that request.
+          schema:
+            type: string
         403:
           description: Forbidden. Authorization is granted but the identity provided does not have sufficient access rights to do that action.
+          schema:
+            type: string
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -1635,9 +2847,10 @@ paths:
       parameters: []
       responses:
         200:
-          description: Success.
+          description: Every ping is answered with a pong.
           schema:
-            type: string
+            type: object
+      x-unitTests: []
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
@@ -1654,279 +2867,270 @@ paths:
       parameters: []
       responses:
         200:
-          description: Provides metrics data. 
+          description: All aggregated runtime metrics for this Marathon instance.
           schema:
-            $ref: '#/definitions/Metricsresponse'
+            $ref: '#/definitions/Metrics'
+      x-unitTests:
+      - request:
+          method: GET
+          uri: /metrics
+        expectedResponse:
+          x-allowExtraHeaders: true
+          x-bodyMatchMode: NONE
+          x-arrayOrderedMatching: false
+          x-arrayCheckCount: false
+          x-matchResponseSchema: true
+          headers: {}
+        x-testShouldPass: true
+        x-testEnabled: true
+        x-testName: Metrics1
+        x-testDescription: Get metrics data from this Marathon instance
       x-operation-settings:
         CollectParameters: false
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
 definitions:
-  ResponseError:
-    title: ResponseError
-    type: string
-    enum:
-    - message
-  V2AppsRestartresponse:
-    title: V2 Apps Restart response
+  Error:
+    title: Error
     type: object
     properties:
-      deploymentId:
+      message:
         type: string
-      version:
-        type: string
+      details:
+        type: array
+        items:
+          $ref: '#/definitions/ErrorDetail'
     required:
-    - deploymentId
-    - version
-  ResponseError4:
-    title: ResponseError4
-    type: string
-    enum:
     - message
-    - deployments
-  V2AppsTasksresponse:
-    title: V2 Apps Tasks response
+  ErrorDetail:
+    title: ErrorDetail
     type: object
     properties:
-      tasks:
+      message:
+        type: string
+      errors:
         type: array
         items:
           type: string
-    required:
-    - tasks
-  V2AppsVersionsresponse:
-    title: V2 Apps Versions response
+  App:
+    title: App
     type: object
     properties:
       id:
         type: string
-      instances:
-        type: integer
-        format: int32
-      cmd:
-        type: string
-      cpus:
-        type: number
-        format: double
-      disk:
-        type: integer
-        format: int32
-      mem:
-        type: integer
-        format: int32
       acceptedResourceRoles:
+        description: >-
+          A list of resource roles.
+
+          Marathon considers only resource offers with roles in this list for
+
+          launching tasks of this app. If you do not specify this,
+
+          Marathon considers all resource offers with roles that have been
+
+          configured by the `--default_accepted_resource_roles` command line flag.
+
+          If no `--default_accepted_resource_roles` was given on startup,
+
+          Marathon considers all resource offers. To register Marathon for a role,
+
+          you need to specify the `--mesos_role` command line flag on startup.
+
+          If you want to assign all resources of a slave to a role,
+
+          you can use the `--default_role` argument when starting up the slave.
+
+          If you need a more fine-grained configuration, you can use the
+
+          `--resources` argument to specify resource shares per role.
+
+          See [the Mesos attribute and resources documentation](http://mesos.apache.org/documentation/latest/attributes-resources/) for details
         type: array
         items:
           type: string
       args:
+        description: >-
+          An array of strings that represents an alternative mode of specifying the
+
+          command to run. This was motivated by safe usage of containerizer features
+
+          like a custom Docker ENTRYPOINT. This args field may be used in place of
+
+          cmd even when using the default command executor.
+
+          This change mirrors API and semantics changes in the Mesos CommandInfo
+
+          protobuf message starting with version `0.20.0`.
+
+          Either `cmd` or `args` must be supplied.
+
+          It is invalid to supply both `cmd` and `args` in the same app.
         type: array
         items:
           type: string
       backoffFactor:
+        description: >-
+          Configures exponential backoff behavior when launching potentially sick
+
+          apps. This prevents sandboxes associated with consecutively failing tasks
+
+          from filling up the hard disk on Mesos slaves.
+
+          The backoff period is multiplied by the factor for each consecutive
+
+          failure until it reaches maxLaunchDelaySeconds.
+
+          This applies also to tasks that are killed due to failing too
+
+          many health checks.
         type: number
+        default: 1.1499999999999999
         format: double
       backoffSeconds:
+        description: >-
+          Configures exponential backoff behavior when launching potentially sick
+
+          apps. This prevents sandboxes associated with consecutively failing tasks
+
+          from filling up the hard disk on Mesos slaves.
+
+          The backoff period is multiplied by the factor for each consecutive
+
+          failure until it reaches maxLaunchDelaySeconds.
+
+          This applies also to tasks that are killed due to failing too
+
+          many health checks.
         type: integer
-        format: int32
-      constraints:
-        type: array
-        items:
-          type: string
-      container:
-        type: string
-      dependencies:
-        type: array
-        items:
-          type: string
-      env:
-        type: string
-      executor:
-        type: string
-      healthChecks:
-        type: array
-        items:
-          type: string
-      readinessChecks:
-        type: array
-        items:
-          type: string
-      labels:
-        type: string
-      maxLaunchDelaySeconds:
-        type: integer
-        format: int32
-      ipAddress:
-        type: string
-      portDefinitions:
-        type: array
-        items:
-          type: string
-      requirePorts:
-        type: boolean
-      upgradeStrategy:
-        type: string
-      fetch:
-        type: array
-        items:
-          type: string
-      user:
-        type: string
-      secrets:
-        type: string
-      taskKillGracePeriodSeconds:
-        type: integer
-        format: int32
-    required:
-    - id
-    - instances
-    - cmd
-    - cpus
-    - disk
-    - mem
-    - acceptedResourceRoles
-    - args
-    - backoffFactor
-    - backoffSeconds
-    - constraints
-    - container
-    - dependencies
-    - env
-    - executor
-    - healthChecks
-    - readinessChecks
-    - labels
-    - maxLaunchDelaySeconds
-    - ipAddress
-    - portDefinitions
-    - requirePorts
-    - upgradeStrategy
-    - fetch
-    - user
-    - secrets
-    - taskKillGracePeriodSeconds
-  V2AppsVersionsresponse21:
-    title: V2 Apps Versions response21
-    type: object
-    properties:
-      versions:
-        type: array
-        items:
-          type: string
-    required:
-    - versions
-  embedEnum:
-    title: embedEnum
-    type: string
-    enum:
-    - Enum_app.tasks
-    - Enum_app.count
-    - Enum_app.deployments
-    - Enum_app.lastTaskFailure
-    - Enum_app.failures
-    - Enum_app.taskStats
-  V2Appsresponse:
-    title: V2 Apps response
-    type: object
-    properties:
-      apps:
-        type: array
-        items:
-          type: string
-    required:
-    - apps
-  AppDefinition:
-    title: AppDefinition
-    type: object
-    properties:
-      acceptedResourceRoles:
-        description: Optional. A list of resource roles. Marathon considers only resource offers with roles in this list for launching tasks of this app. If you do not specify this, Marathon considers all resource offers with roles that have been configured by the `--default_accepted_resource_roles` command line flag. If no `--default_accepted_resource_roles` was given on startup, Marathon considers all resource offers. To register Marathon for a role, you need to specify the `--mesos_role` command line flag on startup. If you want to assign all resources of a slave to a role, you can use the `--default_role` argument when starting up the slave. If you need a more fine-grained configuration, you can use the `--resources` argument to specify resource shares per role. See [the Mesos attribute and resources documentation](http://mesos.apache.org/documentation/latest/attributes-resources/) for details.
-        type: array
-        items:
-          type: string
-      args:
-        description: An array of strings that represents an alternative mode of specifying the command to run. This was motivated by safe usage of containerizer features like a custom Docker ENTRYPOINT. This args field may be used in place of cmd even when using the default command executor. This change mirrors API and semantics changes in the Mesos CommandInfo protobuf message starting with version `0.20.0`.  Either `cmd` or `args` must be supplied. It is invalid to supply both `cmd` and `args` in the same app.
-        type: array
-        items:
-          type: string
-      backoffFactor:
-        description: Configures exponential backoff behavior when launching potentially sick apps. This prevents sandboxes associated with consecutively failing tasks from filling up the hard disk on Mesos slaves. The backoff period is multiplied by the factor for each consecutive failure until it reaches maxLaunchDelaySeconds. This applies also to tasks that are killed due to failing too many health checks.
-        type: number
-        format: double
-      backoffSeconds:
-        description: Configures exponential backoff behavior when launching potentially sick apps. This prevents sandboxes associated with consecutively failing tasks from filling up the hard disk on Mesos slaves. The backoff period is multiplied by the factor for each consecutive failure until it reaches maxLaunchDelaySeconds. This applies also to tasks that are killed due to failing too many health checks.
-        type: integer
+        default: 1
         format: int32
       cmd:
-        description: The command that is executed.  This value is wrapped by Mesos via `/bin/sh -c ${app.cmd}`.  Either `cmd` or `args` must be supplied. It is invalid to supply both `cmd` and `args` in the same app.
+        description: >-
+          The command that is executed.  This value is wrapped by Mesos via
+
+          `/bin/sh -c ${app.cmd}`.
+
+          Either `cmd` or `args` must be supplied.
+
+          It is invalid to supply both `cmd` and `args` in the same app.
         type: string
       constraints:
-        description: Valid constraint operators are one of UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, MAX_PER.
         type: array
         items:
           type: string
       container:
         $ref: '#/definitions/Container'
       cpus:
-        description: The number of CPU shares this application needs per instance. This number does not have to be integer, but can be a fraction.
+        description: The number of CPU shares this application needs per instance. This number does not have to be integer, but can be a fraction.",
         type: number
+        default: 1
         format: double
       dependencies:
-        description: A list of services upon which this application depends. An order is derived from the dependencies for performing start/stop and upgrade of the application. For example, an application /a relies on the services /b which itself relies on /c. To start all 3 applications, first /c is started than /b than /a.
+        description: >-
+          A list of services upon which this application depends
+
+          An order is derived from the dependencies for performing start/stop and
+
+          upgrade of the application. For example, an application /a relies on the
+
+          services /b which itself relies on /c. To start all 3 applications, first
+
+          /c is started than /b than /a.
         type: array
         items:
           type: string
       disk:
-        description: How much disk space in MB is needed for this application. This number does not have to be an integer, but can be a fraction.
+        description: >-
+          How much disk space is needed for this application.
+
+          This number does not have to be an integer, but can be a fraction.
         type: number
+        default: 0
         format: double
       env:
-        type: string
+        type: object
+        additionalProperties:
+          type: object
       executor:
-        description: The executor to use to launch this application. Different executors are available. The simplest one (and the default if none is given) is //cmd, which takes the cmd and executes that on the shell level.
+        description: >-
+          The executor to use to launch this application.
+
+          Different executors are available.
+
+          The simplest one (and the default if none is given) is //cmd,
+
+          which takes the cmd and executes that on the shell level.
         type: string
+        default: //cmd
       fetch:
-        description: Provided URIs are passed to Mesos fetcher module and resolved in runtime.
         type: array
         items:
-          $ref: '#/definitions/Fetch'
+          $ref: '#/definitions/Artifact'
       healthChecks:
         type: array
         items:
-          $ref: '#/definitions/HealthCheck'
-      id:
-        description: Unique identifier for the app consisting of a series of names separated by slashes. Each name must be at least 1 character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The name may not begin or end with a dash.
-        type: string
+          $ref: '#/definitions/AppHealthCheck'
       instances:
-        description: 'The number of instances of this application to start. Please note: this number can be changed any time as needed to scale the application.'
+        description: >-
+          The number of instances of this application to start.
+
+          Please note: this number can be changed any time as needed to
+
+          scale the application.
         type: integer
+        default: 1
         format: int32
       labels:
-        description: Attaching metadata to apps can be useful to expose additional information to other services, so we added the ability to place labels on apps (for example, you could label apps staging and production to mark services by their position in the pipeline).
-        type: string
+        type: object
+        additionalProperties:
+          type: string
       maxLaunchDelaySeconds:
-        description: Configures exponential backoff behavior when launching potentially sick apps. This prevents sandboxes associated with consecutively failing tasks from filling up the hard disk on Mesos slaves. The backoff period is multiplied by the factor for each consecutive failure until it reaches maxLaunchDelaySeconds. This applies also to tasks that are killed due to failing too many health checks.
+        description: >-
+          Configures exponential backoff behavior when launching potentially sick
+
+          apps. This prevents sandboxes associated with consecutively failing tasks
+
+          from filling up the hard disk on Mesos slaves.
+
+          The backoff period is multiplied by the factor for each consecutive
+
+          failure until it reaches maxLaunchDelaySeconds.
+
+          This applies also to tasks that are killed due to failing too many health checks.
         type: integer
+        default: 3600
         format: int32
       mem:
         description: The amount of memory in MB that is needed for the application per instance.
         type: number
+        default: 128
         format: double
       gpus:
         description: The amount of GPU cores that is needed for the application per instance.
         type: integer
+        default: 0
         format: int32
       ipAddress:
-        description: If an application definition includes the 'ipAddress' field, then Marathon will request a per-task IP from Mesos. A separate ports/portMappings configuration is then disallowed.
         $ref: '#/definitions/IpAddress'
       ports:
-        description: An array of required port resources on the agent host. The number of items in the array determines how many dynamic ports are allocated for every task. For every port that is zero, a globally unique (cluster-wide) port is assigned and provided as part of the app definition to be used in load balancing definitions.
+        description: >-
+          An array of required port resources on the agent host.
+
+          The number of items in the array determines how many dynamic ports are
+
+          allocated for every task.
+
+          For every port that is zero, a globally unique (cluster-wide) port is
+
+          assigned and provided as part of the app definition to be used in load
+
+          balancing definitions.
         type: array
         items:
           type: integer
           format: int32
       portDefinitions:
-        description: An array of required port resources on the agent host. The number of items in the array determines how many dynamic ports are allocated for every task. For every port definition with port number zero, a globally unique (cluster-wide) service port is assigned and provided as part of the app definition to be used in load balancing definitions.
         type: array
         items:
           $ref: '#/definitions/PortDefinition'
@@ -1935,28 +3139,51 @@ definitions:
         items:
           $ref: '#/definitions/ReadinessCheck'
       residency:
-        description: When using local persistent volumes that pin tasks onto agents, these values define how Marathon handles terminal states of these tasks.
-        $ref: '#/definitions/Residency'
+        $ref: '#/definitions/AppResidency'
       requirePorts:
-        description: Normally, the host ports of your tasks are automatically assigned. This corresponds to the requirePorts value false which is the default. If you need more control and want to specify your host ports in advance, you can set requirePorts to true. This way the ports you have specified are used as host ports. That also means that Marathon can schedule the associated tasks only on hosts that have the specified ports available.
+        description: >-
+          Normally, the host ports of your tasks are automatically assigned.
+
+          This corresponds to the requirePorts value false which is the default.
+
+          If you need more control and want to specify your host ports in advance,
+
+          you can set requirePorts to true. This way the ports you have specified
+
+          are used as host ports. That also means that Marathon can schedule the
+
+          associated tasks only on hosts that have the specified ports available.
         type: boolean
       secrets:
-        description: A map with named secret declarations. The key is used to reference the values from other places in the app definition.
-        type: string
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/SecretDef'
       storeUrls:
-        description: URL's that have to be resolved and put into the artifact store, before the task will be started.
+        description: >-
+          URL's that have to be resolved and put into the artifact store,
+
+          before the task will be started.
         type: array
         items:
           type: string
       taskKillGracePeriodSeconds:
-        description: Configures the number of seconds between escalating from SIGTERM to SIGKILL when signalling tasks to terminate. Using this grace period, tasks should perform orderly shut down immediately upon receiving SIGTERM.
+        description: >-
+          Configures the number of seconds between escalating from SIGTERM to
+
+          SIGKILL when signalling tasks to terminate.
+
+          Using this grace period, tasks should perform orderly shut down
+
+          immediately upon receiving SIGTERM.
         type: integer
         format: int32
       upgradeStrategy:
-        description: During an upgrade all instances of an application get replaced by a new version. The upgradeStrategy controls how Marathon stops old versions and launches new versions.
         $ref: '#/definitions/UpgradeStrategy'
       uris:
-        description: URIs defined here are resolved, before the application gets started. If the application has external dependencies, they should be defined here.
+        description: >-
+          URIs defined here are resolved, before the application gets started.
+
+          If the application has external dependencies, they should be defined here.
         type: array
         items:
           type: string
@@ -1964,150 +3191,251 @@ definitions:
         description: The user to use to run the tasks on the agent.
         type: string
       version:
-        description: The version of this definition.
+        description: The version of this definition
         type: string
         format: date-time
       versionInfo:
-        description: Detailed version information.
         $ref: '#/definitions/VersionInfo'
+      killSelection:
+        $ref: '#/definitions/KillSelectionEnum'
+      unreachableStrategy:
+        type: object
     required:
     - id
   Container:
     title: Container
     type: object
     properties:
-      docker:
-        $ref: '#/definitions/Docker'
-      appc:
-        $ref: '#/definitions/Appc'
       type:
-        description: Container engine type. Supported engine types at the moment are DOCKER and MESOS.
-        $ref: '#/definitions/Type'
+        $ref: '#/definitions/EngineTypeEnum'
+      docker:
+        $ref: '#/definitions/DockerContainer'
+      appc:
+        $ref: '#/definitions/AppCContainer'
       volumes:
         type: array
         items:
-          $ref: '#/definitions/Volume'
-  Docker:
-    title: Docker
+          $ref: '#/definitions/AppVolume'
+    required:
+    - type
+  EngineTypeEnum:
+    title: EngineTypeEnum
+    description: Container engine type. Supported engine types at the moment are DOCKER and MESOS.
+    type: string
+    enum:
+    - MESOS
+    - DOCKER
+  DockerContainer:
+    title: DockerContainer
     type: object
     properties:
       credential:
-        description: Credential to authenticate with the docker registry.
-        $ref: '#/definitions/Credential'
+        description: >-
+          The credentials to fetch this container.
+
+          Please note: this property is supported only with the Mesos containerizer, not the docker containerizer.
+        $ref: '#/definitions/DockerCredentials'
       forcePullImage:
-        description: The container will be pulled, regardless if it is already available on the local system.
+        description: >-
+          The container will be pulled, regardless if it is already available on
+
+          the local system.
         type: boolean
+        default: false
       image:
-        description: The name of the docker image to use.
+        description: The name of the docker image to use
         type: string
       network:
-        description: The networking mode, this container should operate in. One of BRIDGE|HOST|NONE|USER
-        $ref: '#/definitions/Network'
+        description: >-
+          The network mode of this container.
+
+          Please note: this property is supported only with the docker containerizer, not the Mesos containerizer.
+        $ref: '#/definitions/DockerNetworkEnum'
       parameters:
-        description: Allowing arbitrary parameters to be passed to docker CLI. Note that anything passed to this field is not guaranteed to be supported moving forward, as we might move away from the docker CLI.
         type: array
         items:
-          $ref: '#/definitions/Parameter'
+          $ref: '#/definitions/DockerParameter'
       portMappings:
         type: array
         items:
-          $ref: '#/definitions/PortMapping'
+          $ref: '#/definitions/DockerPortMapping'
       privileged:
-        description: Run this docker image in privileged mode.
+        description: >-
+          Run this docker image in privileged mode
+
+          Please note: this property is supported only with the docker containerizer, not the Mesos containerizer.
         type: boolean
+        default: false
     required:
     - image
-  Credential:
-    title: Credential
+  DockerCredentials:
+    title: DockerCredentials
+    description: Credential to authenticate with the docker registry
     type: object
     properties:
       principal:
-        description: Principal to authenticate with the docker registry.
+        description: Principal to authenticate with the docker registry
         type: string
       secret:
-        description: Secret to authenticate with the docker registry.
+        description: Secret to authenticate with the docker registry
         type: string
     required:
     - principal
-  Network:
-    title: Network
+  DockerNetworkEnum:
+    title: DockerNetworkEnum
+    description: >-
+      The networking mode, this container should operate in.
+
+      One of BRIDGE|HOST|NONE|USER
     type: string
     enum:
     - BRIDGE
     - HOST
     - NONE
     - USER
-  Parameter:
-    title: Parameter
+  DockerParameter:
+    title: DockerParameter
     type: object
     properties:
       key:
-        description: Key of this parameter
+        description: key of this parameter
         type: string
       value:
-        description: Value of this parameter
+        description: value of this parameter
         type: string
     required:
     - key
     - value
-  PortMapping:
-    title: PortMapping
+  DockerPortMapping:
+    title: DockerPortMapping
     type: object
     properties:
       containerPort:
-        description: 'Refers to the port the application listens to inside of the container. It is optional and defaults to 0. For each containerPort with a value of 0 Marathon assigns the containerPort the same value as the assigned hostPort. This is especially useful for apps that advertise the port they are listening on to the outside world for P2P communication. Without containerPort: 0 they would erroneously advertise their private container port which is usually not the same as the externally visible host port.'
+        description: >-
+          Refers to the port the application listens to inside of the
+
+          container.
+
+          It is optional and defaults to 0.
+
+          For each containerPort with a value of 0 Marathon assigns the
+
+          containerPort the same value as the assigned hostPort.
+
+          This is especially useful for apps that advertise the port they
+
+          are listening on to the outside world for P2P communication.
+
+          Without containerPort: 0 they would erroneously advertise their
+
+          private container port which is usually not the same as the
+
+          externally visible host port.
         type: integer
         format: int32
       hostPort:
-        description: Retains the traditional meaning in Marathon, which is a random port from the range included in the Mesos resource offer. The resulting host ports for each task are exposed via the task details in the REST API and the Marathon web UI. hostPort is optional. In BRIDGE mode it defaults to 0 if left unspecified. In USER mode an unspecified hostPort does not allocate a port from a Mesos offer.
+        description: >-
+          Retains the traditional meaning in Marathon, which is a random
+
+          port from the range included in the Mesos resource offer.
+
+          The resulting host ports for each task are exposed via the task
+
+          details in the REST API and the Marathon web UI.
+
+          hostPort is optional.
+
+          In BRIDGE mode it defaults to 0 if left unspecified.
+
+          In USER mode an unspecified hostPort does not allocate a port
+
+          from a Mesos offer.
         type: integer
         format: int32
       labels:
         description: This can be used to add metadata to be interpreted by external applications such as firewalls.
-        type: string
+        type: object
+        additionalProperties:
+          type: string
       name:
         description: Name of the service hosted on this port. If provided, it must be unique over all port mappings.
         type: string
       protocol:
-        description: Protocol of the port (one of ['tcp', 'udp'] or 'udp,tcp' for both). Defaults to 'tcp'.
-        $ref: '#/definitions/Protocol'
+        $ref: '#/definitions/NetworkProtocolEnum'
+        default: tcp
       servicePort:
-        description: Is a helper port intended for doing service discovery using a well-known port per service. The assigned servicePort value is not used/interpreted by Marathon itself but supposed to used by load balancer infrastructure. See Service Discovery Load Balancing doc page. The servicePort parameter is optional and defaults to 0. Like hostPort, If the value is 0, a random port will be assigned. If a servicePort value is assigned by Marathon then Marathon guarantees that its value is unique across the cluster. The values for random service ports are in the range [local_port_min, local_port_max] where local_port_min and local_port_max are command line options with default values of 10000 and 20000, respectively.
+        description: >-
+          Is a helper port intended for doing service discovery using a
+
+          well-known port per service.
+
+          The assigned servicePort value is not used/interpreted by
+
+          Marathon itself but supposed to used by load balancer
+
+          infrastructure.
+
+          See Service Discovery Load Balancing doc page.
+
+          The servicePort parameter is optional and defaults to 0.
+
+          Like hostPort, If the value is 0, a random port will be assigned.
+
+          If a servicePort value is assigned by Marathon then Marathon
+
+          guarantees that its value is unique across the cluster.
+
+          The values for random service ports are in the range
+
+          [local_port_min, local_port_max] where local_port_min and
+
+          local_port_max are command line options with default values of
+
+          10000 and 20000, respectively.
         type: integer
+        default: 0
         format: int32
-  Protocol:
-    title: Protocol
+    required:
+    - containerPort
+  NetworkProtocolEnum:
+    title: NetworkProtocolEnum
+    description: Protocol of the port (tcp, udp)
     type: string
     enum:
     - tcp
     - udp
     - Enum_udp,tcp
-  Appc:
-    title: Appc
+  AppCContainer:
+    title: AppCContainer
     type: object
     properties:
       image:
-        description: The name of the AppC image to use.
+        description: The name of the AppC image to use
         type: string
       id:
-        description: An image ID is a string of the format 'hash-value', where 'hash' is the hash algorithm used and 'value' is the hex-encoded digest. Currently the only permitted hash algorithm is sha512.
+        description: >-
+          An image ID is a string of the format 'hash-value', where 'hash' is
+
+          the hash algorithm used and 'value' is the hex-encoded digest.
+
+          Currently the only permitted hash algorithm is sha512.
         type: string
       labels:
-        description: 'Optional labels. Suggested labels: ''version'', ''os'', and ''arch''.'
-        type: string
+        description: "Optional labels. Suggested labels: 'version', 'os', 'arch'."
+        type: object
+        additionalProperties:
+          type: string
       forcePullImage:
-        description: The container will be pulled, regardless if it is already available on the local system.
+        description: >-
+          The container will be pulled, regardless if it is already available
+
+          on the local system
         type: boolean
+        default: false
     required:
     - image
-  Type:
-    title: Type
-    type: string
-    enum:
-    - MESOS
-    - DOCKER
-  Volume:
-    title: Volume
+  AppVolume:
+    title: AppVolume
     type: object
     properties:
       containerPath:
@@ -2117,28 +3445,51 @@ definitions:
         description: The path of the volume on the host
         type: string
       persistent:
-        $ref: '#/definitions/Persistent'
+        $ref: '#/definitions/PersistentVolume'
       external:
-        $ref: '#/definitions/External'
+        $ref: '#/definitions/ExternalVolume'
       mode:
         description: Possible values are RO for ReadOnly and RW for Read/Write
-        $ref: '#/definitions/Mode'
-  Persistent:
-    title: Persistent
+        $ref: '#/definitions/ReadModeEnum'
+    required:
+    - containerPath
+    - mode
+  PersistentVolume:
+    title: PersistentVolume
+    type: object
+    properties:
+      type:
+        $ref: '#/definitions/PersistentVolumeTypeEnum'
+      size:
+        description: The size of the persistence volume in MB.
+        type: integer
+        format: int64
+      maxSize:
+        description: For `mount` mesos disk resources, the optional maximum size of an exclusive mount volume to be considered.
+        type: integer
+        format: int64
+      constraints:
+        type: array
+        items:
+          type: string
+    required:
+    - size
+  PersistentVolumeTypeEnum:
+    title: PersistentVolumeTypeEnum
+    description: The type of mesos disk resource to use; defaults to root
+    type: string
+    enum:
+    - root
+    - path
+    - mount
+  ExternalVolume:
+    title: ExternalVolume
     type: object
     properties:
       size:
-        description: The size of the persistent volume in MiB
+        description: The size of the external volume in MB
         type: integer
-        format: int32
-  External:
-    title: External
-    type: object
-    properties:
-      size:
-        description: The size of the external volume in MiB
-        type: integer
-        format: int32
+        format: int64
       name:
         description: The name of the volume
         type: string
@@ -2146,245 +3497,436 @@ definitions:
         description: The name of the volume provider
         type: string
       options:
-        description: Provider-specific volume configuration options
-        type: string
-  Mode:
-    title: Mode
+        description: Provider specific volume configuration options
+        type: object
+        additionalProperties:
+          type: string
+  ReadModeEnum:
+    title: ReadModeEnum
     type: string
     enum:
     - RO
     - RW
-  Fetch:
-    title: Fetch
+  Artifact:
+    title: Artifact
     type: object
     properties:
       uri:
-        description: URI to be fetched by Mesos fetcher module
         type: string
-      executable:
-        description: Set fetched artifact as executable
-        type: boolean
       extract:
-        description: Extract fetched artifact if supported by Mesos fetcher module
+        type: boolean
+      executable:
         type: boolean
       cache:
-        description: Cache fetched artifact if supported by Mesos fetcher module
         type: boolean
-      outputFile:
-        description: Rename fetched artifact with the given name
+      destPath:
         type: string
     required:
     - uri
-  HealthCheck:
-    title: HealthCheck
+  AppHealthCheck:
+    title: AppHealthCheck
     type: object
     properties:
       command:
-        type: array
-        items:
-          $ref: '#/definitions/Command'
+        $ref: '#/definitions/CommandCheck'
       gracePeriodSeconds:
-        description: Health check failures are ignored within this number of seconds of the task being started or until the task becomes healthy for the first time.
+        description: >-
+          Health check failures are ignored within this number of seconds of
+
+          the task being started or until the task becomes healthy for the
+
+          first time.
         type: integer
+        default: 300
         format: int32
       ignoreHttp1xx:
-        description: Ignore HTTP 1xx responses.
+        description: Ignore HTTP 1xx responses
         type: boolean
       intervalSeconds:
-        description: Number of seconds to wait between health checks.
+        description: Number of seconds to wait between health checks
         type: integer
+        default: 60
         format: int32
       maxConsecutiveFailures:
-        description: Number of consecutive health check failures after which the unhealthy task should be killed.
+        description: >-
+          Number of consecutive health check failures after which the
+
+          unhealthy task should be killed.
         type: integer
+        default: 3
         format: int32
       path:
-        description: 'Path to endpoint exposed by the task that will provide health status. Example: /path/to/health. Note: only used if protocol == HTTP[S].'
+        description: >-
+          Path to endpoint exposed by the task that will provide health status.
+
+          Note: only used if protocol == HTTP[S]."
         type: string
       port:
-        description: The specific port to connect to. In case of dynamic ports, see portIndex.
+        description: >-
+          The specific port to connect to.
+
+          In case of dynamic ports, see portIndex.
         type: integer
         format: int32
       portIndex:
-        description: Index in this app's ports array to be used for health requests. An index is used so the app can use random ports, like [0, 0, 0] for example, and tasks could be started with port environment variables like $PORT1.
+        description: >-
+          Index in this app's ports array to be used for health requests.
+
+          An index is used so the app can use random ports,
+
+          like [0, 0, 0] for example, and tasks could be started with
+
+          port environment variables like $PORT1.
         type: integer
         format: int32
       protocol:
-        description: Protocol of the requests to be performed. One of HTTP, HTTPS, TCP or COMMAND.
-        $ref: '#/definitions/Protocol47'
+        $ref: '#/definitions/AppHealthCheckProtocolEnum'
+        default: HTTP
       timeoutSeconds:
-        description: Number of seconds after which a health check is considered a failure regardless of the response.
+        description: >-
+          Number of seconds after which a health check is considered a failure
+
+          regardless of the response.
         type: integer
+        default: 20
         format: int32
-  Command:
-    title: Command
+      delaySeconds:
+        description: Amount of time to wait until starting the health checks.
+        type: integer
+        default: 15
+        format: int32
+  CommandCheck:
+    title: CommandCheck
     type: object
     properties:
       value:
-        description: The health check command to execute.
+        description: >-
+          Command line executed by the default shell.
+
+          This process has to return with a zero exit code to indicate the process is healthy.
+
+          Return codes other than null signal, the task is unhealthy.
         type: string
-  Protocol47:
-    title: Protocol47
+    required:
+    - value
+  AppHealthCheckProtocolEnum:
+    title: AppHealthCheckProtocolEnum
+    description: Protocol of the requests to be performed.
     type: string
     enum:
     - HTTP
     - HTTPS
     - TCP
     - COMMAND
+    - MESOS_TCP
+    - MESOS_HTTP
+    - MESOS_HTTPS
   IpAddress:
     title: IpAddress
+    description: >-
+      If an application definition includes the 'ipAddress' field, then Marathon
+
+      will request a per-task IP from Mesos.
+
+      A separate ports/portMappings configuration is then disallowed.
     type: object
     properties:
       discovery:
-        description: Information useful for service discovery.
-        $ref: '#/definitions/Discovery'
+        description: DEPRECATED. Please try to use portMappings instead.
+        $ref: '#/definitions/IpDiscovery'
       groups:
-        description: Array of network groups. One IP address can belong to zero or more network groups. The idea is that containers can only reach containers with which they share at least one network group.
+        description: >-
+          DEPRECATED. Will be ignored in a future release.
+
+          Array of network groups.
+
+          One IP address can belong to zero or more network groups.
+
+          The idea is that containers can only reach containers with which they
+
+          share at least one network group.
         type: array
         items:
           type: string
       labels:
-        description: Key value pair for meta data on that network interface.
-        type: string
+        type: object
+        additionalProperties:
+          type: string
       networkName:
-        description: If present, declares the name of the network that the container should join. In practice it is up to the IPAM to decide how to interpret this field.
+        description: >-
+          If present, declares the name of the network that the container should
+
+          join.
+
+          In practice it is up to the IPAM to decide how to interpret this field
         type: string
-  Discovery:
-    title: Discovery
+  IpDiscovery:
+    title: IpDiscovery
+    description: Information useful for service discovery
     type: object
     properties:
       ports:
-        description: Array of objects describing the ports exposed by each task.
         type: array
         items:
-          $ref: '#/definitions/Port'
-  Port:
-    title: Port
+          $ref: '#/definitions/IpDiscoveryPort'
+  IpDiscoveryPort:
+    title: IpDiscoveryPort
     description: Port
     type: object
     properties:
       number:
-        description: The port number.
+        description: The port number
         type: integer
+        default: 0
         format: int32
       name:
-        description: Name of the port.
+        description: Name of the port
         type: string
       protocol:
-        description: Protocol of the port (one of ['tcp', 'udp']).
-        $ref: '#/definitions/Protocol51'
-  Protocol51:
-    title: Protocol51
-    type: string
-    enum:
-    - tcp
-    - udp
+        $ref: '#/definitions/NetworkProtocolEnum'
+        default: tcp
+    required:
+    - name
   PortDefinition:
     title: PortDefinition
     type: object
     properties:
       port:
-        description: if requirePorts is set to true, then this port number will be used on the agent host Otherwise if the requirePorts is set to false and this port number is not zero, then it will be used as a service port and a dynamic port will be used on the agent host. If it is set to zero, a dynamic port will be used on the host and a unique service port will be assigned by Marathon.
+        description: >-
+          If requirePorts is set to true, then this port number will be used
+
+          on the agent host. Otherwise if the requirePorts is set to false and
+
+          this port number is not zero, then it will be used as a service port
+
+          and a dynamic port will be used on the agent host.
+
+          If it is set to zero, a dynamic port will be used on the host and a
+
+          unique service port will be assigned by Marathon.
         type: integer
+        default: 0
         format: int32
       labels:
-        description: This can be used to add metadata to be interpreted by external applications such as firewalls.
-        type: string
+        type: object
+        additionalProperties:
+          type: string
       name:
-        description: Name of the service hosted on this port. If provided, it must be unique over all port definitions.
+        description: >-
+          Name of the service hosted on this port.
+
+          If provided, it must be unique over all port definitions.
         type: string
       protocol:
-        description: Protocol of the port (one of ['tcp', 'udp']). Defaults to 'tcp'.
-        $ref: '#/definitions/Protocol51'
+        description: If this port is used for tcp or udp or both.
+        $ref: '#/definitions/NetworkProtocolEnum'
+        default: tcp
   ReadinessCheck:
     title: ReadinessCheck
     description: Query these readiness checks to determine if a task is ready to serve requests.
     type: object
     properties:
       name:
-        description: The name used to identify this readiness check.
+        description: The name used to identify this readiness check
         type: string
+        default: readinessCheck
       protocol:
-        description: Protocol of the requests to be performed. One of HTTP, HTTPS.
-        $ref: '#/definitions/Protocol55'
+        $ref: '#/definitions/HttpSchemeEnum'
+        default: HTTP
       path:
-        description: 'Path to endpoint exposed by the task that will provide readiness status. Example: /path/to/health.'
+        description: Path to endpoint exposed by the task that will provide readiness status.
         type: string
+        default: /
       portName:
-        description: 'Name of the port to query as described in the portDefinitions. Example: http-api.'
+        description: Name of the port to query as described in the portDefinitions.
         type: string
+        default: http-api
       intervalSeconds:
-        description: Number of seconds to wait between readiness checks. Defaults to 30 seconds
+        description: Number of seconds to wait between readiness checks.
         type: integer
+        default: 30
         format: int32
       timeoutSeconds:
-        description: Number of seconds after which a health check is considered a failure regardless of the response. Must be smaller than intervalSeconds. Defaults to 10 seconds.
+        description: >-
+          Number of seconds after which a health check is considered a failure
+
+          regardless of the response.
+
+          Must be smaller than intervalSeconds.
         type: integer
+        default: 10
         format: int32
       httpStatusCodesForReady:
-        description: The HTTP(s) status code to treat as 'ready'.
+        description: The HTTP(s) status codes to treat as 'ready'
         type: array
         items:
           type: integer
           format: int32
       preserveLastResponse:
-        description: If and only if true, preserve the last readiness check responses and expose them in the API as part of a deployment..
+        description: >-
+          If and only if true, preserve the last readiness check responses and
+
+          expose them in the API as part of a deployment.
         type: boolean
-  Protocol55:
-    title: Protocol55
+        default: false
+  HttpSchemeEnum:
+    title: HttpSchemeEnum
+    description: The http scheme to use
     type: string
     enum:
     - HTTP
     - HTTPS
-  Residency:
-    title: Residency
+  AppResidency:
+    title: AppResidency
+    description: >-
+      When using local persistent volumes that pin tasks onto agents,
+
+      these values define how Marathon handles terminal states of these tasks.
     type: object
     properties:
       relaunchEscalationTimeoutSeconds:
-        description: When a task using persistent local volumes cannot be restarted on the agent it's been pinned to, Marathon will try to launch this task on another node after this timeout. Defaults to 3600 (one hour).
+        description: >-
+          When a task using persistent local volumes cannot be restarted on the
+
+          agent it's been pinned to, Marathon will try to launch this task on
+
+          another node after this timeout. Defaults to 3600 (one hour).",
         type: integer
         format: int32
       taskLostBehavior:
-        description: When Marathon receives a TASK_LOST status update indicating that the agent running the task is gone, this property defines whether Marathon will launch the task on another node or not. Defaults to WAIT_FOREVER
-        $ref: '#/definitions/TaskLostBehavior'
-  TaskLostBehavior:
-    title: TaskLostBehavior
+        $ref: '#/definitions/TaskLostBehaviorEnum'
+    required:
+    - relaunchEscalationTimeoutSeconds
+    - taskLostBehavior
+  TaskLostBehaviorEnum:
+    title: TaskLostBehaviorEnum
+    description: >-
+      When Marathon receives a TASK_LOST status update indicating that the
+
+      agent running the task is gone, this property defines whether Marathon
+
+      will launch the task on another node or not. Defaults to WAIT_FOREVER"
     type: string
     enum:
     - WAIT_FOREVER
     - RELAUNCH_AFTER_TIMEOUT
+  SecretDef:
+    title: SecretDef
+    description: A secret declaration
+    type: object
+    properties:
+      source:
+        description: >-
+          The source of the secrets value.
+
+          The format dependes on the secret store
+        type: string
+    required:
+    - source
   UpgradeStrategy:
     title: UpgradeStrategy
+    description: >-
+      During an upgrade all instances of an application get replaced by a new
+
+      version.
+
+      The upgradeStrategy controls how Marathon stops old versions and
+
+      launches new versions.
     type: object
     properties:
       maximumOverCapacity:
-        description: A number between 0 and 1 which is multiplied with the instance count. This is the maximum number of additional instances launched at any point of time during the upgrade process.
+        description: >-
+          A number between 0 and 1 which is multiplied with the instance count.
+
+          This is the maximum number of additional instances launched at any
+
+          point of time during the upgrade process.
         type: number
         format: double
       minimumHealthCapacity:
-        description: A number between 0 and 1 that is multiplied with the instance count. This is the minimum number of healthy nodes that do not sacrifice overall application purpose. Marathon will make sure, during the upgrade process, that at any point of time this number of healthy instances are up.
+        description: >-
+          A number between 0 and 1 that is multiplied with the instance count.
+
+          This is the minimum number of healthy nodes that do not sacrifice
+
+          overall application purpose. Marathon will make sure, during the
+
+          upgrade process, that at any point of time this number of healthy
+
+          instances are up.
         type: number
         format: double
+    required:
+    - maximumOverCapacity
+    - minimumHealthCapacity
   VersionInfo:
     title: VersionInfo
+    description: Detailed version information
     type: object
     properties:
       lastScalingAt:
-        description: Contains the time stamp of the last change to this app which was not simply a scaling or a restarting configuration.
+        description: Contains the timestamp of the last change to this pod which was not simply a scaling or restarting configuration
         type: string
         format: date-time
       lastConfigChangeAt:
-        description: Contains the time stamp of the last change including changes like scaling or restarting the app. Since our versions are time based, this is currently equal to version.
+        description: Contains the timestamp of the last change including changes like scaling or restarting.
         type: string
         format: date-time
-  ResponseError61:
-    title: ResponseError61
+    required:
+    - lastScalingAt
+    - lastConfigChangeAt
+  KillSelectionEnum:
+    title: KillSelectionEnum
+    description: Defines which instance is killed first.
     type: string
     enum:
-    - message
-    - details
-  embedEnum71:
-    title: embedEnum71
+    - YOUNGEST_FIRST
+    - OLDEST_FIRST
+  EmbedEnum:
+    title: embedEnum
+    description: >-
+      Embeds nested resources that match the supplied path. You can specify this parameter multiple times with different values. <br/>
+
+      - <code>app.tasks</code>. embed tasks Note&#58; if this embed is definded, it automatically sets <code>apps.deployments</code> but this will change in a future release. Please define all embeds explicitly.
+
+      - <code>app.counts</code>. embed all task counts (tasksStaged, tasksRunning, tasksHealthy, tasksUnhealthy) <br/> Note&#58; currently embedded by default but this will change in a future release. Please define all embeds explicitly.
+
+      - <code>app.deployments</code>. embed all deployment identifier, if the related app currently is in deployment.
+
+      - <code>app.readiness</code> embed all readiness check results
+
+      - <code>app.lastTaskFailure</code> embeds the lastTaskFailure for the application if there is one.
+
+      - <code>app.failures</code> Shorthand for apps.lastTaskFailure, apps.tasks, apps.counts and apps.deployments.<br/> Note&#58; deprecated and will be removed in future versions Please define all embeds explicitly.
+
+      - <code>app.taskStats</code> exposes task statistics in the JSON.
+    type: string
+    enum:
+    - Enum_app.tasks
+    - Enum_app.count
+    - Enum_app.deployments
+    - Enum_app.lastTaskFailure
+    - Enum_app.failures
+    - Enum_app.taskStats
+  EmbedEnum35:
+    title: embedEnum35
+    description: >-
+      Embeds nested resources that match the supplied path. You can specify this parameter multiple times with different values.
+
+      - <code>apps.tasks</code> embed all tasks of each application<br/> Note&#58; if this embed is definded, it automatically sets <code>apps.deployments</code> but this will change in a future release. Please define all embeds explicitly.
+
+      - <code>apps.counts</code> embed all task counts (tasksStaged, tasksRunning, tasksHealthy, tasksUnhealthy) <br/> Note&#58; currently embedded by default but this will change in a future release. Please define all embeds explicitly.
+
+      - <code>apps.deployments</code> embed all deployment identifier, if the related app currently is in deployment.
+
+      - <code>apps.readiness</code> embed all readiness check results
+
+      - <code>apps.lastTaskFailure</code> embeds the lastTaskFailure for the application if there is one.
+
+      - <code>apps.failures</code> Shorthand for apps.lastTaskFailure, apps.tasks, apps.counts and apps.deployments.<br/> Note&#58; deprecated and will be removed in future versions Please define all embeds explicitly.
+
+      - <code>apps.taskStats</code> exposes task statistics in the JSON.
     type: string
     enum:
     - Enum_apps.tasks
@@ -2393,8 +3935,849 @@ definitions:
     - Enum_apps.lastTaskFailure
     - Enum_apps.failures
     - Enum_apps.taskStats
-  embedEnum124:
-    title: embedEnum124
+  Pod:
+    title: Pod
+    description: >
+      A pod allows one to launch a collection co-located (on the same agent) containers
+
+      that share the same network namespace and that may share the same ca725b4e-4dda-4a4f-ab28-75dc778ac087-volumes.
+
+      Resources are specified on a per-container basis.
+    type: object
+    properties:
+      id:
+        type: string
+      labels:
+        description: >-
+          Metadata as key/value pair.
+
+          Useful when passing directives to be interpreted by Mesos modules.
+        type: object
+        additionalProperties:
+          type: string
+      version:
+        description: The version of the definition, immutable
+        type: string
+        format: date-time
+      user:
+        description: >-
+          The OS user to use to run the tasks on the agent.
+
+          May be overridden by a ca725b4e-4dda-4a4f-ab28-75dc778ac087-container.
+        type: string
+      environment:
+        description: >-
+          Environment Variables to set at the pod level.
+
+          Individual containers may override them
+        type: object
+        additionalProperties:
+          type: object
+      containers:
+        type: array
+        items:
+          $ref: '#/definitions/PodContainer'
+      secrets:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/SecretDef'
+      volumes:
+        type: array
+        items:
+          $ref: '#/definitions/Volume'
+      networks:
+        type: array
+        items:
+          $ref: '#/definitions/Network'
+      scaling:
+        $ref: '#/definitions/PodScalingPolicy'
+      scheduling:
+        $ref: '#/definitions/PodSchedulingPolicy'
+      executorResources:
+        description: The resources to allocate to the executor.
+        $ref: '#/definitions/ExecutorResources'
+    required:
+    - id
+    - containers
+  PodContainer:
+    title: PodContainer
+    description: Mesos Container
+    type: object
+    properties:
+      name:
+        description: The name of this container
+        type: string
+      exec:
+        $ref: '#/definitions/MesosExec'
+      resources:
+        description: The resources to allocate to the container.
+        $ref: '#/definitions/Resources'
+      endpoints:
+        type: array
+        items:
+          $ref: '#/definitions/Endpoint'
+      image:
+        description: The filesystem image to populate the container with
+        $ref: '#/definitions/Image'
+      environment:
+        type: object
+        additionalProperties:
+          type: object
+      user:
+        description: >-
+          The OS user to use to run the tasks on the agent.
+
+          Values here override a "user" value specified in the pod definition.
+        type: string
+      healthCheck:
+        description: All healthchecks to perform on the container
+        $ref: '#/definitions/HealthCheck'
+      volumeMounts:
+        type: array
+        items:
+          $ref: '#/definitions/VolumeMount'
+      artifacts:
+        type: array
+        items:
+          $ref: '#/definitions/Artifact'
+      labels:
+        description: >-
+          Metadata as key/value pair.
+
+          Useful when passing directives to be interpreted by Mesos modules.
+        type: object
+        additionalProperties:
+          type: string
+      lifecycle:
+        $ref: '#/definitions/Lifecycle'
+    required:
+    - name
+    - resources
+  MesosExec:
+    title: MesosExec
+    type: object
+    properties:
+      command:
+        description: >-
+          Command specification executed by Mesos, not parsed by Marathon.
+
+          The presence of `command.shell` implies `overrideEntrypoint=true`.
+        type: object
+      overrideEntrypoint:
+        description: >-
+          When true argv[0] will be used as the entrypoint/exec of the container.
+
+          Otherwise the contents of argv[] are appended as arguments.
+        type: boolean
+    required:
+    - command
+  Resources:
+    title: Resources
+    description: Resource Allocations
+    type: object
+    properties:
+      cpus:
+        description: The number of CPU shares this pod needs per instance. This number does not have to be integer, but can be a fraction.
+        type: number
+        format: double
+      mem:
+        description: The amount of memory in MB that is needed for the pod instance
+        type: number
+        format: double
+      disk:
+        description: How much disk space is needed for this application. This number does not have to be an integer, but can be a fraction.
+        type: number
+        default: 0
+        format: double
+      gpus:
+        description: The amount of GPU cores that are needed for the pod
+        type: integer
+        default: 0
+        format: int32
+    required:
+    - cpus
+    - mem
+  Endpoint:
+    title: Endpoint
+    description: >-
+      Endpoints accept connections from outside of a pod.
+
+      Endpoints may also be advertised outside of a cluster.
+    type: object
+    properties:
+      name:
+        description: Name of this port. Should be unique in the context of the pod.
+        type: string
+      containerPort:
+        description: >-
+          The container port that a task's process is actually listening on.
+
+          Required if the network mode is container
+        type: integer
+        format: int32
+      hostPort:
+        description: >-
+          Mapped port on the host.
+
+          All host ports are allocated from resource offers.
+        type: integer
+        format: int32
+      protocol:
+        description: >-
+          The protocol of this port, advertised in Mesos DiscoveryInfo (DI).
+
+          Specifying more than one protocol here will result in the generation
+
+          of multiple Port DI entries.
+        type: array
+        items:
+          type: string
+      labels:
+        description: >-
+          Metadata as key/value pair. Possible uses include VIPs,
+
+          per-network-interface binding
+        type: object
+        additionalProperties:
+          type: string
+    required:
+    - name
+  Image:
+    title: Image
+    type: object
+    properties:
+      kind:
+        $ref: '#/definitions/ImageTypeEnum'
+      id:
+        description: address/identifier of the file system image
+        type: string
+      forcePull:
+        description: true if the image should always be pulled
+        type: boolean
+      labels:
+        description: >-
+          Used during image discovery and dependency resolution.
+
+          Several well-known labels are defined:
+
+          version: the version of this image
+
+          os: (default: linux) operating system
+
+          arch: (default: amd64) architecture
+        type: object
+        additionalProperties:
+          type: string
+    required:
+    - kind
+    - id
+  ImageTypeEnum:
+    title: ImageTypeEnum
+    type: string
+    enum:
+    - DOCKER
+    - APPC
+  HealthCheck:
+    title: HealthCheck
+    type: object
+    properties:
+      http:
+        $ref: '#/definitions/HttpHealthCheck'
+      tcp:
+        $ref: '#/definitions/TcpHealthCheck'
+      exec:
+        description: >-
+          Command that executes some health check process.
+
+          Use with pods requires Mesos v1.2 or higher.
+        $ref: '#/definitions/CommandHealthCheck'
+      gracePeriodSeconds:
+        description: >-
+          Health check failures are ignored within this number of seconds of
+
+          the task being started or until the task becomes healthy for the
+
+          first time.
+        type: integer
+        default: 300
+        format: int32
+      intervalSeconds:
+        description: Interval between the health checks
+        type: integer
+        default: 60
+        format: int32
+      maxConsecutiveFailures:
+        description: Number of consecutive failures until the task will be killed
+        type: integer
+        default: 3
+        format: int32
+      timeoutSeconds:
+        description: Amount of time to wait for the health check to complete.
+        type: integer
+        default: 20
+        format: int32
+      delaySeconds:
+        description: Amount of time to wait until starting the health checks.
+        type: integer
+        default: 15
+        format: int32
+  HttpHealthCheck:
+    title: HttpHealthCheck
+    type: object
+    properties:
+      endpoint:
+        description: >-
+          The endpoint name to use.
+
+          In "host" mode health checks use the hostPort. In other modes use the containerPort.
+        type: string
+      path:
+        type: string
+      scheme:
+        $ref: '#/definitions/HttpSchemeEnum'
+    required:
+    - endpoint
+  TcpHealthCheck:
+    title: TcpHealthCheck
+    type: object
+    properties:
+      endpoint:
+        description: >-
+          The endpoint name to use.
+
+          In "host" mode health checks use the hostPort. In other modes use the containerPort.
+        type: string
+    required:
+    - endpoint
+  CommandHealthCheck:
+    title: CommandHealthCheck
+    type: object
+    properties:
+      command:
+        type: object
+    required:
+    - command
+  VolumeMount:
+    title: VolumeMount
+    type: object
+    properties:
+      name:
+        description: The name of the volume to reference.
+        type: string
+      mountPath:
+        description: The path inside the container at which the volume is mounted.
+        type: string
+      readOnly:
+        type: boolean
+    required:
+    - name
+    - mountPath
+  Lifecycle:
+    title: Lifecycle
+    type: object
+    properties:
+      killGracePeriodSeconds:
+        description: >-
+          After a SIGTERM is sent to a container instance, Mesos will wait this number of seconds
+
+          before issuing a SIGKILL.
+        type: number
+        format: double
+  Volume:
+    title: Volume
+    type: object
+    properties:
+      name:
+        description: The name of the volume to reference.
+        type: string
+      host:
+        description: >-
+          Absolute path of the file or directory on the agent, or else the relative
+
+          path of the directory in the executor's sandbox.
+
+          Host volumes are useful for mapping directories that exist on the agent apriori,
+
+          or within the executor sandbox. No resources (Mesos or otherwise) are allocated for
+
+          these types of volumes.
+        type: string
+    required:
+    - name
+  Network:
+    title: Network
+    type: object
+    properties:
+      name:
+        description: >-
+          Defines the name of the container network to join.
+
+          Not for use with `host` mode networking.
+        type: string
+      mode:
+        $ref: '#/definitions/NetworkModeEnum'
+        default: container
+      labels:
+        description: >-
+          Labels applied to the pod's NetworkInfo.
+
+          Ignored when using `host` node networking.
+        type: object
+        additionalProperties:
+          type: string
+  NetworkModeEnum:
+    title: NetworkModeEnum
+    type: string
+    enum:
+    - container
+    - host
+  PodScalingPolicy:
+    title: PodScalingPolicy
+    description: Add new possible super-types as different scaling policies are supported.
+    type: object
+    properties:
+      kind:
+        $ref: '#/definitions/PodScalingPolicyTypeEnum'
+    required:
+    - kind
+  PodScalingPolicyTypeEnum:
+    title: PodScalingPolicyTypeEnum
+    type: string
+    enum:
+    - Enum_fixed
+  PodSchedulingPolicy:
+    title: PodSchedulingPolicy
+    type: object
+    properties:
+      backoff:
+        $ref: '#/definitions/PodSchedulingBackoffStrategy'
+      upgrade:
+        $ref: '#/definitions/PodUpgradeStrategy'
+      placement:
+        $ref: '#/definitions/PodPlacementPolicy'
+      killSelection:
+        $ref: '#/definitions/KillSelectionEnum'
+      unreachableStrategy:
+        type: object
+  PodSchedulingBackoffStrategy:
+    title: PodSchedulingBackoffStrategy
+    description: >-
+      Configures exponential backoff behavior when launching potentially sick apps.
+
+      This prevents sandboxes associated with consecutively failing tasks from filling up the hard disk on Mesos slaves.
+
+      The backoff period is multiplied by the factor for each consecutive failure until it reaches maxLaunchDelaySeconds.
+
+      This applies also to tasks that are killed due to failing too many health checks.
+    type: object
+    properties:
+      backoff:
+        description: The initial backoff (seconds) applied when a launched instance fails.
+        type: number
+        default: 1
+        format: double
+      backoffFactor:
+        description: The factor applied to the current backoff to determine the new backoff.
+        type: number
+        default: 1.1499999999999999
+        format: double
+      maxLaunchDelay:
+        description: The maximum backoff (seconds) applied when subsequent failures are detected.
+        type: number
+        default: 3600
+        format: double
+  PodUpgradeStrategy:
+    title: PodUpgradeStrategy
+    description: >-
+      During an upgrade all instances of an application get replaced by a new version.
+
+      The upgradeStrategy controls how Marathon stops old versions and launches new versions.
+    type: object
+    properties:
+      minimumHealthCapacity:
+        description: >-
+          A number between 0and 1 that is multiplied with the instance count.
+
+          This is the minimum number of healthy nodes that do not sacrifice overall application purpose.
+
+          Marathon will make sure, during the upgrade process, that at any point of time this number of healthy instances are up.
+        type: number
+        default: 1
+        format: double
+      maximumOverCapacity:
+        description: >-
+          A number between 0 and 1 which is multiplied with the instance count.
+
+          This is the maximum number of additional instances launched at any point of time during the upgrade process.
+        type: number
+        default: 1
+        format: double
+  PodPlacementPolicy:
+    title: PodPlacementPolicy
+    type: object
+    properties:
+      constraints:
+        type: array
+        items:
+          $ref: '#/definitions/Constraint'
+      acceptedResourceRoles:
+        type: array
+        items:
+          type: string
+  Constraint:
+    title: Constraint
+    type: object
+    properties:
+      fieldName:
+        type: string
+      operator:
+        $ref: '#/definitions/ConstraintOperatorEnum'
+      value:
+        type: string
+    required:
+    - fieldName
+    - operator
+  ConstraintOperatorEnum:
+    title: ConstraintOperatorEnum
+    type: string
+    enum:
+    - UNIQUE
+    - CLUSTER
+    - GROUP_BY
+    - LIKE
+    - UNLIKE
+    - MAX_PER
+  ExecutorResources:
+    title: ExecutorResources
+    description: Executor Resource Allocations. Same as Resources but reserved for the pod executor.
+    type: object
+    properties:
+      cpus:
+        description: The number of CPU shares this pod needs per instance for its executor. This number does not have to be integer, but can be a fraction.
+        type: number
+        default: 0.10000000000000001
+        format: double
+      mem:
+        description: The amount of memory in MB that is needed for the pod instance for the pod instance's executor
+        type: number
+        default: 32
+        format: double
+      disk:
+        description: How much disk space is needed for for the executor. This number does not have to be an integer, but can be a fraction.
+        type: number
+        default: 10
+        format: double
+  PodStatus:
+    title: PodStatus
+    description: >
+      Pod status communicates the lifecycle phase of the pod, current instance and container
+
+      status, and recent termination status history.
+    type: object
+    properties:
+      id:
+        type: string
+      spec:
+        description: The latest version of the pod specification (that has the same pod ID).
+        $ref: '#/definitions/Pod'
+      status:
+        $ref: '#/definitions/PodStateEnum'
+      statusSince:
+        description: Time at which the status code was last modified.
+        type: string
+        format: date-time
+      message:
+        description: Human-friendly explanation for reason of the current status.
+        type: string
+      instances:
+        type: array
+        items:
+          $ref: '#/definitions/PodInstanceStatus'
+      terminationHistory:
+        description: >-
+          List of most recent instance terminations.
+
+          TODO(jdef) determine how many items might show up here; current thinking is .. not many
+        type: array
+        items:
+          $ref: '#/definitions/TerminationHistory'
+      lastUpdated:
+        description: Time that this status object was last checked and updated (even if nothing changed)
+        type: string
+        format: date-time
+      lastChanged:
+        description: Time that this status object was last modified (some aspect of status did change)
+        type: string
+        format: date-time
+    required:
+    - id
+    - spec
+    - status
+    - statusSince
+    - lastUpdated
+    - lastChanged
+  PodStateEnum:
+    title: PodStateEnum
+    description: >-
+      DEGRADED - The number of STABLE pod instances is less than the number of desired instances.
+
+      STABLE   - All launched pod instances have started and, if health checks were specified, are all healthy.
+
+      TERMINAL - Marathon is tearing down all of the instances for this d459d6a7-1060-462b-9a99-cb2966e57801-pod.
+    type: string
+    enum:
+    - DEGRADED
+    - STABLE
+    - TERMINAL
+  PodInstanceStatus:
+    title: PodInstanceStatus
+    type: object
+    properties:
+      id:
+        description: >-
+          Unique ID of this pod instance in the cluster.
+
+          TODO(jdef) Probably represents the Mesos executor ID.
+        type: string
+      status:
+        $ref: '#/definitions/PodInstanceStateEnum'
+      statusSince:
+        description: Time at which the status code was last modified.
+        type: string
+        format: date-time
+      message:
+        description: Human-friendly explanation for reason of the current status.
+        type: string
+      conditions:
+        type: array
+        items:
+          $ref: '#/definitions/StatusCondition'
+      agentHostname:
+        description: >-
+          Hostname that this instance was launched on.
+
+          May be an IP address if the agent was configured to advertise its hostname that way.
+        type: string
+      resources:
+        description: >-
+          Sum of all resources allocated for this pod instance.
+
+          May include additional, system-allocated resources for the default executor.
+        $ref: '#/definitions/Resources'
+      networks:
+        description: Status of the networks to which this instance is attached.
+        type: array
+        items:
+          $ref: '#/definitions/NetworkStatus'
+      containers:
+        type: array
+        items:
+          $ref: '#/definitions/ContainerStatus'
+      specReference:
+        description: Location of the version of the pod specification this instance was created from.
+        type: string
+      lastUpdated:
+        description: Time that this status was last checked and updated (even if nothing changed)
+        type: string
+        format: date-time
+      lastChanged:
+        description: Time that this status was last modified (some aspect of status did change)
+        type: string
+        format: date-time
+    required:
+    - id
+    - status
+    - statusSince
+    - lastUpdated
+    - lastChanged
+  PodInstanceStateEnum:
+    title: PodInstanceStateEnum
+    description: >-
+      PENDING  - Instance is queued for launch.
+
+      STAGING  - Instance has been launched but is not yet running.
+
+      STABLE   - Any terminated containers have completed successfully and any running containers
+                 are healthy (TBD by health checks, if enabled).
+      DEGRADED - One or more containers are running but the instance is not considered STABLE.
+
+      TERMINAL - Instance is in the process of shutting down.
+    type: string
+    enum:
+    - PENDING
+    - STAGING
+    - STABLE
+    - DEGRADED
+    - TERMINAL
+  StatusCondition:
+    title: StatusCondition
+    type: object
+    properties:
+      name:
+        description: >-
+          Human and machine-readable name of this condition.
+
+          For example "healthy", "disk-full".
+        type: string
+      lastChanged:
+        description: last time the value field was changed for this condition
+        type: string
+        format: date-time
+      lastUpdated:
+        description: last time this condition was updated (value may not have changed)
+        type: string
+        format: date-time
+      value:
+        description: the state of the condition. may be boolean or some enumeration-derived value
+        type: string
+      reason:
+        description: a machine-readable value that systems use to reason about the state of the condition
+        type: string
+    required:
+    - name
+    - lastChanged
+    - lastUpdated
+    - value
+  NetworkStatus:
+    title: NetworkStatus
+    type: object
+    properties:
+      name:
+        description: name of the network
+        type: string
+      addresses:
+        type: array
+        items:
+          type: string
+  ContainerStatus:
+    title: ContainerStatus
+    type: object
+    properties:
+      name:
+        description: name of the container specification (within the pod)
+        type: string
+      status:
+        type: string
+      statusSince:
+        description: Time at which the status code was last modified.
+        type: string
+        format: date-time
+      message:
+        description: Human-friendly explanation for the container's current status.
+        type: string
+      conditions:
+        type: array
+        items:
+          $ref: '#/definitions/StatusCondition'
+      containerId:
+        description: >-
+          Unique ID of this container in the cluster.
+
+          TODO(jdef) Probably represents the Mesos task ID.
+        type: string
+      endpoints:
+        type: array
+        items:
+          $ref: '#/definitions/ContainerEndpointStatus'
+      resources:
+        description: Resources in use by this d459d6a7-1060-462b-9a99-cb2966e57801-container.
+        $ref: '#/definitions/Resources'
+      termination:
+        $ref: '#/definitions/ContainerTerminationState'
+      lastUpdated:
+        description: Time that this status was last checked and updated (even if nothing changed)
+        type: string
+        format: date-time
+      lastChanged:
+        description: Time that this status was last modified (some aspect of status did change)
+        type: string
+        format: date-time
+    required:
+    - name
+    - status
+    - statusSince
+    - lastUpdated
+    - lastChanged
+  ContainerEndpointStatus:
+    title: ContainerEndpointStatus
+    type: object
+    properties:
+      name:
+        description: name of the endpoint
+        type: string
+      allocatedHostPort:
+        type: integer
+        format: int32
+      healthy:
+        description: true if a health check is defined for this endpoint and is passing
+        type: boolean
+    required:
+    - name
+  ContainerTerminationState:
+    title: ContainerTerminationState
+    type: object
+    properties:
+      exitCode:
+        type: integer
+        format: int32
+      message:
+        description: Human-explanation for container termination.
+        type: string
+  TerminationHistory:
+    title: TerminationHistory
+    type: object
+    properties:
+      instanceID:
+        type: string
+      startedAt:
+        type: string
+        format: date-time
+      terminatedAt:
+        type: string
+        format: date-time
+      message:
+        description: Human-friendly explanation for termination.
+        type: string
+      containers:
+        type: array
+        items:
+          $ref: '#/definitions/ContainerTerminationHistory'
+    required:
+    - instanceID
+    - startedAt
+    - terminatedAt
+  ContainerTerminationHistory:
+    title: ContainerTerminationHistory
+    type: object
+    properties:
+      containerId:
+        type: string
+      lastKnownState:
+        type: string
+      termination:
+        $ref: '#/definitions/ContainerTerminationState'
+    required:
+    - containerId
+  EmbedEnum116:
+    title: embedEnum116
+    description: >-
+      Embeds nested resources that match the supplied path. You can specify this parameter multiple times with different values. Unknown embed parameters are ignored. If you omit this parameter, it defaults to <code>group.groups</code>, <code>group.apps</code>
+
+      - <code>group.groups</code> embed all child groups of each group<br/>
+
+      - <code>group.apps</code> embed all apps of each group<br/>
+
+      - <code>group.apps.tasks</code> embed all tasks of each application<br/>
+
+      - <code>group.apps.counts</code> embed all task counts (tasksStaged, tasksRunning, tasksHealthy, tasksUnhealthy) <br/>
+
+      - <code>group.apps.deployments</code> embed all deployment identifier, if the related app currently is in deployment.
+
+      - <code>group.apps.readiness</code> embed all readiness check results
+
+      - <code>group.apps.lastTaskFailure</code> embeds the lastTaskFailure for the application if there is one.
+
+      - <code>group.apps.taskStats</code> exposes task statistics in the JSON.
     type: string
     enum:
     - Enum_group.groups
@@ -2410,286 +4793,169 @@ definitions:
     type: object
     properties:
       id:
-        description: Unique identifier for the app consisting of a series of names separated by slashes. Each name must be at least 1 character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The name may not begin or end with a dash.
         type: string
       apps:
-        description: The list of AppDefinitions in this group. See AppDefinition.json for the schema.
         type: array
         items:
           $ref: '#/definitions/App'
+      pods:
+        type: array
+        items:
+          $ref: '#/definitions/PodStatus'
       groups:
-        description: Groups can build a tree. Each group can contain sub-groups. The sub-groups are defined here.
+        description: >-
+          Groups can build a tree.
+
+          Each group can contain sub-groups.
+
+          The sub-groups are defined here.
         type: array
         items:
           $ref: '#/definitions/Group'
       dependencies:
-        description: A list of services upon which this application depends. An order is derived from the dependencies for performing start/stop and upgrade of the application. For example, an application /a relies on the services /b which itself relies on /c. To start all 3 applications, first /c is started than /b than /a.
+        description: >-
+          A list of services that this group depends on.
+
+          An order is derived from the dependencies for performing start/stop and
+
+          upgrade of the application. For example, an application /a relies on the
+
+          services /b which itself relies on /c. To start all 3 applications,
+
+          first /c is started than /b than /a.
         type: array
         items:
           type: string
       version:
-        description: The version of this definition.
         type: string
         format: date-time
     required:
     - id
-  App:
-    title: App
-    type: object
-    properties:
-      acceptedResourceRoles:
-        description: Optional. A list of resource roles. Marathon considers only resource offers with roles in this list for launching tasks of this app. If you do not specify this, Marathon considers all resource offers with roles that have been configured by the `--default_accepted_resource_roles` command line flag. If no `--default_accepted_resource_roles` was given on startup, Marathon considers all resource offers. To register Marathon for a role, you need to specify the `--mesos_role` command line flag on startup. If you want to assign all resources of a slave to a role, you can use the `--default_role` argument when starting up the slave. If you need a more fine-grained configuration, you can use the `--resources` argument to specify resource shares per role. See [the Mesos attribute and resources documentation](http://mesos.apache.org/documentation/latest/attributes-resources/) for details.
-        type: array
-        items:
-          type: string
-      args:
-        description: An array of strings that represents an alternative mode of specifying the command to run. This was motivated by safe usage of containerizer features like a custom Docker ENTRYPOINT. This args field may be used in place of cmd even when using the default command executor. This change mirrors API and semantics changes in the Mesos CommandInfo protobuf message starting with version `0.20.0`.  Either `cmd` or `args` must be supplied. It is invalid to supply both `cmd` and `args` in the same app.
-        type: array
-        items:
-          type: string
-      backoffFactor:
-        description: Configures exponential backoff behavior when launching potentially sick apps. This prevents sandboxes associated with consecutively failing tasks from filling up the hard disk on Mesos slaves. The backoff period is multiplied by the factor for each consecutive failure until it reaches maxLaunchDelaySeconds. This applies also to tasks that are killed due to failing too many health checks.
-        type: number
-        format: double
-      backoffSeconds:
-        description: Configures exponential backoff behavior when launching potentially sick apps. This prevents sandboxes associated with consecutively failing tasks from filling up the hard disk on Mesos slaves. The backoff period is multiplied by the factor for each consecutive failure until it reaches maxLaunchDelaySeconds. This applies also to tasks that are killed due to failing too many health checks.
-        type: integer
-        format: int32
-      cmd:
-        description: The command that is executed.  This value is wrapped by Mesos via `/bin/sh -c ${app.cmd}`.  Either `cmd` or `args` must be supplied. It is invalid to supply both `cmd` and `args` in the same app.
-        type: string
-      constraints:
-        description: Valid constraint operators are one of UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE, MAX_PER.
-        type: array
-        items:
-          type: string
-      container:
-        $ref: '#/definitions/Container'
-      cpus:
-        description: The number of CPU shares this application needs per instance. This number does not have to be integer, but can be a fraction.
-        type: number
-        format: double
-      dependencies:
-        description: A list of services upon which this application depends. An order is derived from the dependencies for performing start/stop and upgrade of the application. For example, an application /a relies on the services /b which itself relies on /c. To start all 3 applications, first /c is started than /b than /a.
-        type: array
-        items:
-          type: string
-      disk:
-        description: How much disk space in MB is needed for this application. This number does not have to be an integer, but can be a fraction.
-        type: number
-        format: double
-      env:
-        type: string
-      executor:
-        description: The executor to use to launch this application. Different executors are available. The simplest one (and the default if none is given) is //cmd, which takes the cmd and executes that on the shell level.
-        type: string
-      fetch:
-        description: Provided URIs are passed to Mesos fetcher module and resolved in runtime.
-        type: array
-        items:
-          $ref: '#/definitions/Fetch'
-      healthChecks:
-        type: array
-        items:
-          $ref: '#/definitions/HealthCheck'
-      id:
-        description: Unique identifier for the app consisting of a series of names separated by slashes. Each name must be at least 1 character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The name may not begin or end with a dash.
-        type: string
-      instances:
-        description: 'The number of instances of this application to start. Please note: this number can be changed any time as needed to scale the application.'
-        type: integer
-        format: int32
-      labels:
-        description: Attaching metadata to apps can be useful to expose additional information to other services, so we added the ability to place labels on apps (for example, you could label apps staging and production to mark services by their position in the pipeline).
-        type: string
-      maxLaunchDelaySeconds:
-        description: Configures exponential backoff behavior when launching potentially sick apps. This prevents sandboxes associated with consecutively failing tasks from filling up the hard disk on Mesos slaves. The backoff period is multiplied by the factor for each consecutive failure until it reaches maxLaunchDelaySeconds. This applies also to tasks that are killed due to failing too many health checks.
-        type: integer
-        format: int32
-      mem:
-        description: The amount of memory in MB that is needed for the application per instance.
-        type: number
-        format: double
-      gpus:
-        description: The amount of GPU cores that is needed for the application per instance.
-        type: integer
-        format: int32
-      ipAddress:
-        description: If an application definition includes the 'ipAddress' field, then Marathon will request a per-task IP from Mesos. A separate ports/portMappings configuration is then disallowed.
-        $ref: '#/definitions/IpAddress'
-      ports:
-        description: An array of required port resources on the agent host. The number of items in the array determines how many dynamic ports are allocated for every task. For every port that is zero, a globally unique (cluster-wide) port is assigned and provided as part of the app definition to be used in load balancing definitions.
-        type: array
-        items:
-          type: integer
-          format: int32
-      portDefinitions:
-        description: An array of required port resources on the agent host. The number of items in the array determines how many dynamic ports are allocated for every task. For every port definition with port number zero, a globally unique (cluster-wide) service port is assigned and provided as part of the app definition to be used in load balancing definitions.
-        type: array
-        items:
-          $ref: '#/definitions/PortDefinition'
-      readinessChecks:
-        type: array
-        items:
-          $ref: '#/definitions/ReadinessCheck'
-      residency:
-        description: When using local persistent volumes that pin tasks onto agents, these values define how Marathon handles terminal states of these tasks.
-        $ref: '#/definitions/Residency'
-      requirePorts:
-        description: Normally, the host ports of your tasks are automatically assigned. This corresponds to the requirePorts value false which is the default. If you need more control and want to specify your host ports in advance, you can set requirePorts to true. This way the ports you have specified are used as host ports. That also means that Marathon can schedule the associated tasks only on hosts that have the specified ports available.
-        type: boolean
-      secrets:
-        description: A map with named secret declarations. The key is used to reference the values from other places in the app definition.
-        type: string
-      storeUrls:
-        description: URL's that have to be resolved and put into the artifact store, before the task will be started.
-        type: array
-        items:
-          type: string
-      taskKillGracePeriodSeconds:
-        description: Configures the number of seconds between escalating from SIGTERM to SIGKILL when signalling tasks to terminate. Using this grace period, tasks should perform orderly shut down immediately upon receiving SIGTERM.
-        type: integer
-        format: int32
-      upgradeStrategy:
-        description: During an upgrade all instances of an application get replaced by a new version. The upgradeStrategy controls how Marathon stops old versions and launches new versions.
-        $ref: '#/definitions/UpgradeStrategy'
-      uris:
-        description: URIs defined here are resolved, before the application gets started. If the application has external dependencies, they should be defined here.
-        type: array
-        items:
-          type: string
-      user:
-        description: The user to use to run the tasks on the agent.
-        type: string
-      version:
-        description: The version of this definition.
-        type: string
-        format: date-time
-      versionInfo:
-        description: Detailed version information.
-        $ref: '#/definitions/VersionInfo'
-    required:
-    - id
-  V2TasksDeleterequest:
-    title: V2 Tasks Delete request
-    type: object
-    properties:
-      ids:
-        type: array
-        items:
-          type: string
-    required:
-    - ids
-  statusEnum:
+  StatusEnum:
     title: statusEnum
+    description: Filter the list of tasks by status
     type: string
     enum:
     - running
     - staging
-  V2EventSubscriptionsresponse:
-    title: V2 EventSubscriptions response
-    type: object
-    properties:
-      callbackUrls:
-        type: array
-        items:
-          type: string
-    required:
-    - callbackUrls
-  V2EventSubscriptionsresponse204:
-    title: V2 EventSubscriptions response204
-    type: object
-    properties:
-      callbackUrl:
-        type: string
-      clientIp:
-        type: string
-      eventType:
-        type: string
-    required:
-    - callbackUrl
-    - clientIp
-    - eventType
-  V2Inforesponse:
-    title: V2 Info response
-    type: object
-    properties:
-      name:
-        type: string
-      version:
-        type: string
-      elected:
-        type: boolean
-      leader:
-        type: string
-      frameworkId:
-        type: string
-      marathon_config:
-        type: string
-      zookeeper_config:
-        type: string
-      event_subscriber:
-        type: string
-      http_config:
-        type: string
-    required:
-    - name
-    - version
-    - elected
-    - leader
-    - frameworkId
-    - marathon_config
-    - zookeeper_config
-    - event_subscriber
-    - http_config
-  V2Leaderresponse:
-    title: V2 Leader response
-    type: object
-    properties:
-      leader:
-        type: string
-    required:
-    - leader
-  V2Pluginsresponse:
-    title: V2 Plugins response
-    type: object
-    properties:
-      plugins:
-        type: array
-        items:
-          type: string
-    required:
-    - plugins
-  V2Queueresponse:
-    title: V2 Queue response
+  Queue:
+    title: Queue
     type: object
     properties:
       queue:
         type: array
         items:
-          type: string
-    required:
-    - queue
-  Metricsresponse:
-    title: Metrics response
+          type: object
+  Metrics:
+    title: Metrics
     type: object
     properties:
-      counters:
+      start:
         type: string
-      gauges:
+        format: date-time
+      end:
         type: string
+        format: date-time
       histograms:
-        type: string
-      meters:
-        type: string
-      timers:
-        type: string
-      version:
-        type: string
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Histogram'
+      counters:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Counter'
+      gauges:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Histogram'
+      min-max-counter:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/Histogram'
     required:
+    - start
+    - end
+    - histograms
     - counters
     - gauges
-    - histograms
-    - meters
-    - timers
-    - version
+    - min-max-counter
+  Histogram:
+    title: Histogram
+    type: object
+    properties:
+      count:
+        description: The number of samples
+        type: integer
+        format: int64
+      min:
+        description: The minimum value
+        type: integer
+        format: int64
+      max:
+        description: The maximum value
+        type: integer
+        format: int64
+      p50:
+        description: The 50th percentile median value
+        type: integer
+        format: int64
+      p75:
+        description: The 75th percentile median value
+        type: integer
+        format: int64
+      p98:
+        description: The 98th percentile median value
+        type: integer
+        format: int64
+      p99:
+        description: The 99th percentile median value
+        type: integer
+        format: int64
+      p999:
+        description: The 999th percentile median value
+        type: integer
+        format: int64
+      mean:
+        description: The average of all samples
+        type: number
+        format: double
+      tags:
+        description: metadata about the metric
+        type: object
+        additionalProperties:
+          type: string
+      unit:
+        description: The unit of measurement
+        type: object
+    required:
+    - count
+    - min
+    - max
+    - p50
+    - p75
+    - p98
+    - p99
+    - p999
+    - mean
+    - tags
+    - unit
+  Counter:
+    title: Counter
+    type: object
+    properties:
+      count:
+        description: The current value
+        type: integer
+        format: int64
+      tags:
+        description: metadata about the metric
+        type: object
+        additionalProperties:
+          type: string
+      unit:
+        description: The unit of measurement
+        type: object
+    required:
+    - count
+    - tags
+    - unit


### PR DESCRIPTION
## Description
Generated from the latest master RAML:

```git clone https://github.com/mesosphere/marathon.git
cd marathon/docs/docs/rest-api/public/api
zip -r api.zip .
sudo pip install --upgrade apimatic-cli
apimatic-cli transform fromuser --email ${email} --password ${password} --file api.zip --format SwaggerYaml --download-to . --download-as marathon.yaml
```

Remove
- `info.license`

Replace:
- `host: example.com`
- `basePath: /service/marathon (edited)`

## Urgency
- [ ] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [X] High
- [ ] Medium
