### PR TITLE
Replace /var/lib/zookeeper with /var/lib/dcos/exhibitor/zookeeper

### DIFF
--- a/1.8/administration/installing/custom/advanced.md
+++ b/1.8/administration/installing/custom/advanced.md
@@ -31,7 +31,7 @@ The DC/OS installation creates these folders:
     <td>Contains copies of the units in `/etc/systemd/system/dcos.target.wants`. They must be at the top folder as well as inside `dcos.target.wants`.</td>
   </tr>
   <tr>
-    <td><code>/var/lib/zookeeper</code></td>
+    <td><code>/var/lib/dcos/exhibitor/zookeeper</code></td>
     <td>Contains the [ZooKeeper](/docs/1.8/overview/concepts/#zookeeper) data.</td>
   </tr>
   <tr>

--- a/1.8/administration/installing/custom/cli.md
+++ b/1.8/administration/installing/custom/cli.md
@@ -28,7 +28,7 @@ The DC/OS installation creates these folders:
     <td>Contains copies of the units in `/etc/systemd/system/dcos.target.wants`. They must be at the top folder as well as inside `dcos.target.wants`.</td>
   </tr>
   <tr>
-    <td><code>/var/lib/zookeeper</code></td>
+    <td><code>/var/lib/dcos/exhibitor/zookeeper</code></td>
     <td>Contains the [ZooKeeper](/docs/1.8/overview/concepts/#zookeeper) data.</td>
   </tr>
   <tr>

--- a/1.8/administration/installing/custom/gui.md
+++ b/1.8/administration/installing/custom/gui.md
@@ -28,7 +28,7 @@ The DC/OS installation creates these folders:
     <td>Contains copies of the units in `/etc/systemd/system/dcos.target.wants`. They must be at the top folder as well as inside `dcos.target.wants`.</td>
   </tr>
   <tr>
-    <td><code>/var/lib/zookeeper</code></td>
+    <td><code>/var/lib/dcos/exhibitor/zookeeper</code></td>
     <td>Contains the [ZooKeeper](/docs/1.8/overview/concepts/#zookeeper) data.</td>
   </tr>
   <tr>
@@ -131,7 +131,7 @@ The DC/OS installation creates these folders:
    **Important:* If you exit your GUI installation before launching DC/OS, you must do this before reinstalling:
 
     *   SSH to each node in your cluster and run `rm -rf /opt/mesosphere`.
-    *   SSH to your bootstrap master node and run `rm -rf /var/lib/zookeeper`
+    *   SSH to your bootstrap master node and run `rm -rf /var/lib/dcos/exhibitor/zookeeper`
 
     ![preflight](../img/dcos-gui-run-preflight.png)
 

--- a/1.9/administration/installing/custom/advanced.md
+++ b/1.9/administration/installing/custom/advanced.md
@@ -31,7 +31,7 @@ The DC/OS installation creates these folders:
     <td>Contains copies of the units in `/etc/systemd/system/dcos.target.wants`. They must be at the top folder as well as inside `dcos.target.wants`.</td>
   </tr>
   <tr>
-    <td><code>/var/lib/zookeeper</code></td>
+    <td><code>/var/lib/dcos/exhibitor/zookeeper</code></td>
     <td>Contains the [ZooKeeper](/docs/1.9/overview/concepts/#zookeeper) data.</td>
   </tr>
   <tr>

--- a/1.9/administration/installing/custom/cli.md
+++ b/1.9/administration/installing/custom/cli.md
@@ -28,7 +28,7 @@ The DC/OS installation creates these folders:
     <td>Contains copies of the units in `/etc/systemd/system/dcos.target.wants`. They must be at the top folder as well as inside `dcos.target.wants`.</td>
   </tr>
   <tr>
-    <td><code>/var/lib/zookeeper</code></td>
+    <td><code>/var/lib/dcos/exhibitor/zookeeper</code></td>
     <td>Contains the [ZooKeeper](/docs/1.9/overview/concepts/#zookeeper) data.</td>
   </tr>
   <tr>

--- a/1.9/administration/installing/custom/gui.md
+++ b/1.9/administration/installing/custom/gui.md
@@ -28,7 +28,7 @@ The DC/OS installation creates these folders:
     <td>Contains copies of the units in `/etc/systemd/system/dcos.target.wants`. They must be at the top folder as well as inside `dcos.target.wants`.</td>
   </tr>
   <tr>
-    <td><code>/var/lib/zookeeper</code></td>
+    <td><code>/var/lib/dcos/exhibitor/zookeeper</code></td>
     <td>Contains the [ZooKeeper](/docs/1.9/overview/concepts/#zookeeper) data.</td>
   </tr>
   <tr>
@@ -131,7 +131,7 @@ The DC/OS installation creates these folders:
    **Important:* If you exit your GUI installation before launching DC/OS, you must do this before reinstalling:
 
     *   SSH to each node in your cluster and run `rm -rf /opt/mesosphere`.
-    *   SSH to your bootstrap master node and run `rm -rf /var/lib/zookeeper`
+    *   SSH to your bootstrap master node and run `rm -rf /var/lib/dcos/exhibitor/zookeeper`
 
     ![preflight](../img/dcos-gui-run-preflight.png)
 


### PR DESCRIPTION
Starting from DC/OS 1.8 this ZooKeeper stores its data at `/var/lib/dcos/exhibitor/zookeeper`.
## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
