### PR TITLE
v1.8 - Swap Nodes & Network on usage/GUI

### DIFF
--- a/1.8/usage/webinterface.md
+++ b/1.8/usage/webinterface.md
@@ -63,6 +63,12 @@ The Jobs tab provides native support for creating and administering scheduled jo
 
 ![Jobs](../img/dcos-jobs.png)
 
+# <a name="network"></a>Network
+
+The Network tab provides information helpful for troubleshooting your virtual networks. You can see which containers are on which network and see their IP addresses. For more information, see the [documentation](/docs/1.8/administration/virtual-networks/ip-per-container/).
+
+![Network](../img/ui-dashboard-network.gif)
+
 # <a name="nodes"></a>Nodes
 
 The Nodes tab provides a comprehensive view of all of the nodes that are used across your cluster. You can view a graph that shows the allocation percentage rate for CPU, memory, or disk.
@@ -76,12 +82,6 @@ You can switch to **Grid** view to see a "donuts" percentage visualization.
 ![Nodes](../img/dcos-donuts.png)
 
 Clicking on a node opens the Nodes side panel, which provides CPU, memory, and disk usage graphs and lists all tasks on the node. Use the dropdown or a custom filter to sort tasks and click on details for more information. Click on a task listed on the Nodes side panel to see detailed information about the task’s CPU, memory, and disk usage and the task’s files and directory tree.
-
-# <a name="network"></a>Network
-
-The Network tab provides information helpful for troubleshooting your virtual networks. You can see which containers are on which network and see their IP addresses. For more information, see the [documentation](/docs/1.8/administration/virtual-networks/ip-per-container/).
-
-![Network](../img/ui-dashboard-network.gif)
 
 # <a name="universe"></a>Universe
 


### PR DESCRIPTION
The 1.8 DC/OS GUI has Network before Nodes as well as the intro section that lists the tabs. Reordering the content to be consistent.

## Description
Didn't create one due to simplicity of change but can if preferred

## Urgency
- [ ] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [ ] High
- [ ] Medium
- [x] Low

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
