### PR TITLE
Explicitly install docker-engine-selinux-1.13.1

### DIFF
--- a/1.9/administration/installing/custom/system-requirements/install-docker-centos.md
+++ b/1.9/administration/installing/custom/system-requirements/install-docker-centos.md
@@ -81,7 +81,7 @@ The following instructions demonstrate how to use Docker with OverlayFS on CentO
 1.  Install the Docker engine, daemon, and service. 
 
     ```bash
-    sudo yum install -y docker-engine-1.13.1
+    sudo yum install -y docker-engine-1.13.1 docker-engine-selinux-1.13.1
     sudo systemctl start docker
     sudo systemctl enable docker
     ```


### PR DESCRIPTION
## Description
Otherwise docker-engine-1.13.1 will pull in the wrong version of docker-engine-selinux.

## Urgency
- [x] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
