### PR TITLE
Update elk.md

### DIFF
--- a/1.9/administration/logging/aggregating/elk.md
+++ b/1.9/administration/logging/aggregating/elk.md
@@ -171,9 +171,9 @@ For each Agent node in your DC/OS cluster:
     sudo chmod 0755 /etc/systemd/system/dcos-journalctl-filebeat.service
     sudo systemctl daemon-reload
     sudo systemctl start dcos-journalctl-filebeat.service
-    sudo chkconfig dcos-journalctl-filebeat.service on
+    sudo systemctl enable dcos-journalctl-filebeat.service
     sudo systemctl start filebeat
-    sudo chkconfig filebeat on
+    sudo systemctl enable filebeat
     ```
 
 # <a name="all"></a>Step 3: ELK Node Notes


### PR DESCRIPTION
Replace chkconfig on with systemctl enable

## Description
Systemctl enable is the preferred method in CentOS 7. 

## Urgency
Low

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
