### PR TITLE
remove broken anchor link

### DIFF
--- a/1.9/deploying-services/config-universe-service.md
+++ b/1.9/deploying-services/config-universe-service.md
@@ -37,7 +37,7 @@ This topic describes how to use the DC/OS CLI to configure services. You can als
     nano marathon-config.json
     ```
 
-3.  Use the `properties` objects (see [Discovering the default parameters](#discover-defaults)) to build your JSON options file. For example, to change the number of Marathon CPU shares to 3 and memory allocation to 2048:
+3.  Use the `properties` objects to build your JSON options file. For example, to change the number of Marathon CPU shares to 3 and memory allocation to 2048:
 
     ```json
     {


### PR DESCRIPTION
This anchor link didn't work and it seems clear from context what the properties object is.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
