### PR TITLE
Update Logging API swagger and examples

### DIFF
--- a/1.9/api/logs.yaml
+++ b/1.9/api/logs.yaml
@@ -8,9 +8,10 @@ info:
     Note that the endpoints in this spec are all *service-specific*. dcos-log
     is designed to be put behind Admin Router, which provides security for these
     endpoints. Therefore, on a DC/OS cluster, the final URL to query will resemble:
-        http://<host>/system/v1/agent/<agent-id>/logs/v1/<endpoint>
-    For more information, please consult the project documentation located at
-    <https://github.com/dcos/dcos-log>.
+    `http://{cluster-url}/system/v1/agent/{agent-id}/logs/v1/{resource-path}`
+    For more information, see
+    [DC/OS Logging](http://localhost:3000/docs/latest/monitoring/logging/) or
+    the [DC/OS Log Source](https://github.com/dcos/dcos-log).
 basePath: "/v1"
 parameters:
   filter:
@@ -62,6 +63,8 @@ paths:
     get:
       description: |
         Gets a range of logs from the beggining of the journal.
+      tags:
+        - range
       parameters:
         - $ref: "#/parameters/filter"
         - $ref: "#/parameters/limit"
@@ -85,6 +88,8 @@ paths:
     get:
       description: |
         Download compressed logs.
+      tags:
+        - range
       parameters:
         - $ref: "#/parameters/filter"
         - $ref: "#/parameters/limit"
@@ -109,6 +114,8 @@ paths:
     get:
       description: |
         Gets a range of task logs.
+      tags:
+        - range
       parameters:
         - $ref: "#/parameters/filter"
         - $ref: "#/parameters/limit"
@@ -132,6 +139,8 @@ paths:
     get:
       description: |
         Download compressed task logs.
+      tags:
+        - range
       parameters:
         - $ref: "#/parameters/filter"
         - $ref: "#/parameters/limit"
@@ -156,6 +165,8 @@ paths:
     get:
       description: |
         Stream the log entries back to client with Server-Sent-Events.
+      tags:
+        - stream
       parameters:
         - $ref: "#/parameters/filter"
         - $ref: "#/parameters/limit"
@@ -177,6 +188,8 @@ paths:
     get:
       description: |
         Stream the task log entries back to client with Server-Sent-Events.
+      tags:
+        - stream
       parameters:
         - $ref: "#/parameters/filter"
         - $ref: "#/parameters/limit"
@@ -198,6 +211,8 @@ paths:
     get:
       description: |
         Get all available unique values for a given field.
+      tags:
+        - fields
       responses:
         200:
           description: Successful response.

--- a/1.9/monitoring/logging/logging-api-examples.md
+++ b/1.9/monitoring/logging/logging-api-examples.md
@@ -13,15 +13,13 @@ This topic provides common usage examples for the Logging API.
 - [jq](https://stedolan.github.io/jq/)
 - [DC/OS](/docs/1.9/installing/)
 - [DC/OS CLI](/docs/1.9/cli/) must be installed, configured, and logged in.
-- Extract the `DCOS_URL` and `DCOS_AUTH_TOKEN` from the DC/OS CLI...
+- Extract `DCOS_URL` and `DCOS_AUTH_TOKEN` from the DC/OS CLI:
 
-The [DC/OS CLI](/docs/1.9/cli/) must be installed, configured, and logged in. Then, extract `DCOS_URL` and `DCOS_AUTH_TOKEN` from the DC/OS CLI:
-
-```
-DCOS_URL="$(dcos config show core.dcos_url)"
-DCOS_URL="${DCOS_URL%/}" # strip trailing slash, if present
-DCOS_AUTH_TOKEN="$(dcos config show core.dcos_acs_token)"
-```
+    ```
+    DCOS_URL="$(dcos config show core.dcos_url)"
+    DCOS_URL="${DCOS_URL%/}" # strip trailing slash, if present
+    DCOS_AUTH_TOKEN="$(dcos config show core.dcos_acs_token)"
+    ```
 
 # Node Logs
 

--- a/1.9/monitoring/logging/logging-api-examples.md
+++ b/1.9/monitoring/logging/logging-api-examples.md
@@ -1,0 +1,86 @@
+---
+post_title: Logging API Examples
+feature_maturity: preview
+menu_order: 4
+---
+
+The following examples exercise the Logging API using [Bash](https://www.gnu.org/software/bash/), [Curl](https://curl.haxx.se/), and [jq](https://stedolan.github.io/jq/).
+
+The [DC/OS CLI](/docs/1.9/cli/) must be installed, configured, and logged in. Then, extract `DCOS_URL` and `DCOS_AUTH_TOKEN` from the DC/OS CLI:
+
+```
+DCOS_URL="$(dcos config show core.dcos_url)"
+DCOS_URL="${DCOS_URL%/}" # strip trailing slash, if present
+DCOS_AUTH_TOKEN="$(dcos config show core.dcos_acs_token)"
+```
+
+# Tail
+
+Get the last 10 entries from the journal and follow new events:
+
+```
+curl -k -H "Authorization: token=${DCOS_AUTH_TOKEN}" "${DCOS_URL}/system/v1/logs/v1/stream/?skip_prev=10"
+```
+
+# Range
+
+Skip 100 entries from the beginning of the journal and return the next 10 entries:
+
+```
+curl -k -H "Authorization: token=${DCOS_AUTH_TOKEN}" "${DCOS_URL}/system/v1/logs/v1/range/?skip_next=100&limit=10"
+```
+
+# Plain Text
+
+Skip 200 entries from the beginning of the journal and return the next entry in plain text:
+
+```
+curl -k -H "Accept: text/plain" -H "Authorization: token=${DCOS_AUTH_TOKEN}" "${DCOS_URL}/system/v1/logs/v1/range/?skip_next=200&limit=1"
+```
+
+# JSON
+
+Skip 200 entries from the beginning of the journal and return the next entry in JSON:
+
+```
+curl -k -H "Accept: application/json" -H "Authorization: token=${DCOS_AUTH_TOKEN}" "${DCOS_URL}/system/v1/logs/v1/range/?skip_next=200&limit=1"
+```
+
+# Event Stream
+
+Skip 200 entries from the beginning of the journal and return the next entry as an event stream:
+
+```
+curl -k -H "Accept: text/event-stream" -H "Authorization: token=${DCOS_AUTH_TOKEN}" "${DCOS_URL}/system/v1/logs/v1/range/?skip_next=200&limit=1"
+```
+
+# Event Stream Cursor
+
+Get all logs after a specific cursor and follow new events:
+
+```
+# Get the 10th line in json and parse its cursor
+CURSOR="$(curl -k -H "Accept: application/json" -H "Authorization: token=${DCOS_AUTH_TOKEN}" "${DCOS_URL}/system/v1/logs/v1/range/?skip_next=9&limit=1" | jq -r ".cursor")"
+
+# Follow the stream in plain text starting at the 11th line using the cursor
+curl -k -H "Authorization: token=${DCOS_AUTH_TOKEN}" "${DCOS_URL}/system/v1/logs/v1/stream/" --get --data-urlencode "cursor=${CURSOR}"
+```
+
+The cursor must be URL encoded.
+
+# Range Cursor
+
+Get 1,000 log lines, 100 at a time:
+
+```
+TIMES=10 # number of times to call the endpoint
+LINES=100 # number of log lines to retrieve per call
+CURSOR="" # first call uses an empty cursor to start from the beginning
+for i in $(seq 1 ${TIMES}); do
+  BUFFER="$(curl -k -H "Accept: application/json" -H "Authorization: token=${DCOS_AUTH_TOKEN}" "${DCOS_URL}/system/v1/logs/v1/range/?limit=${LINES}" --get --data-urlencode "cursor=${CURSOR}")"
+  echo "${BUFFER}"
+  CURSOR="$(echo "${BUFFER}" | jq -r ".cursor" | tail -1)"
+done
+```
+
+Each call uses the cursor of the last line from the previous call. The cursor must be URL encoded.

--- a/1.9/monitoring/logging/logging-api.md
+++ b/1.9/monitoring/logging/logging-api.md
@@ -10,8 +10,10 @@ The Logging API is backed by the [DC/OS Log component](/docs/1.9/overview/archit
 
 For more information about using the Logging API, see [Logging](/docs/1.9/monitoring/logging/).
 
+For usage examples, see [Logging API Examples](/docs/1.9/monitoring/logging/logging-api-examples/).
 
-## Routes
+
+# Routes
 
 Access to the Logging API is proxied through the Admin Router on each node using the following route:
 
@@ -28,7 +30,7 @@ Access to the Logging API of the agent nodes is also proxied through the master 
 To determine the address of your cluster, see [Cluster Access](/docs/1.9/api/access/).
 
 
-## Format
+# Format
 
 The API request header can be any the following:
 
@@ -37,7 +39,7 @@ The API request header can be any the following:
 - `text/event-stream` request logs in Server-Sent-Events format.
 
 
-## Resources
+# Resources
 
 The following resources are available under both of the above routes:
 
@@ -47,63 +49,6 @@ The following resources are available under both of the above routes:
 
   <div class="info" id="api_info">
     <div class="info_title">Loading docs...</div>
-  <div class="info_description markdown"></div>
+    <div class="info_description markdown"></div>
+  </div>
 </div>
-
-
-## Examples
-
-## GET parameters
-- `/system/v1/logs/v1/stream/?skip_prev=10` get the last 10 entires from the journal and follow new events.
-- `/system/v1/logs/v1/range/?skip_next=100&limit=10` skip 100 entries from the beggining of the journal and return 10 following entries.
-- `/system/v1/logs/v1/stream/?cursor=s%3Dcea8150abb0543deaab113ed2f39b014%3Bi%3D1%3Bb%3D2c357020b6e54863a5ac9dee71d5872c%3Bm%3D33ae8a1%3Bt%3D53e52ec99a798%3Bx%3Db3fe26128f768a49` get all logs after the specific cursor and follow new events.
-- `/system/v1/logs/v1/range/?cursor=s%3Dcea8150abb0543deaab113ed2f39b014%3Bi%3D1%3Bb%3D2c357020b6e54863a5ac9dee71d5872c%3Bm%3D33ae8a1%3Bt%3D53e52ec99a798%3Bx%3Db3fe26128f768a49&skip_prev=2&limit=2` get 2 entries. The first one is the one before the cursor position and the second one is the entry with given cursor position.
-
-## Accept: text/plain
-
-```
-curl -H 'Accept: text/plain' '127.0.0.1:80/system/v1/logs/v1/range/?skip_prev=200&limit=1'
-Wed Oct 12 06:28:20 2016 a60c1d059aea systemd [1] Starting Daily Cleanup of Temporary Directories.
-```
-
-## Accept: application/json
-
-```
-curl -H 'Accept: application/json' '127.0.0.1:80/system/v1/logs/v1/range/?skip_prev=200&limit=1' | jq '.'
-{
-  "fields": {
-    "CODE_FILE": "../src/core/unit.c",
-    "CODE_FUNCTION": "unit_status_log_starting_stopping_reloading",
-    "CODE_LINE": "1272",
-    "MESSAGE": "Starting Daily Cleanup of Temporary Directories.",
-    "MESSAGE_ID": "7d4958e842da4a758f6c1cdc7b36dcc5",
-    "PRIORITY": "6",
-    "SYSLOG_FACILITY": "3",
-    "SYSLOG_IDENTIFIER": "systemd",
-    "UNIT": "systemd-tmpfiles-clean.timer",
-    "_BOOT_ID": "637573ba91ae4008b58eaa9505a11f86",
-    "_CAP_EFFECTIVE": "3fffffffff",
-    "_CMDLINE": "/sbin/init",
-    "_COMM": "systemd",
-    "_EXE": "/lib/systemd/systemd",
-    "_GID": "0",
-    "_HOSTNAME": "a60c1d059aea",
-    "_MACHINE_ID": "48230110dd084e91b7b6885728b98295",
-    "_PID": "1",
-    "_SOURCE_REALTIME_TIMESTAMP": "1476253700204523",
-    "_SYSTEMD_CGROUP": "e",
-    "_TRANSPORT": "journal",
-    "_UID": "0"
-  },
-  "cursor": "s=f78aeb5184144e2a94963a42b0cac49e;i=262;b=637573ba91ae4008b58eaa9505a11f86;m=6fbb8f76b;t=53ea51966297e;x=69cba0539a7e4576",
-  "monotonic_timestamp": 29993006955,
-  "realtime_timestamp": 1476253700204926
-}
-```
-
-## Accept: text/event-stream
-```
-curl -H 'Accept: text/event-stream' '127.0.0.1:80/system/v1/logs/v1/range/?skip_prev=200&limit=1'
-id: s=f78aeb5184144e2a94963a42b0cac49e;i=262;b=637573ba91ae4008b58eaa9505a11f86;m=6fbb8f76b;t=53ea51966297e
-data: {"fields":{"CODE_FILE":"../src/core/unit.c","CODE_FUNCTION":"unit_status_log_starting_stopping_reloading","CODE_LINE":"1272","MESSAGE":"Starting Daily Cleanup of Temporary Directories.","MESSAGE_ID":"7d4958e842da4a758f6c1cdc7b36dcc5","PRIORITY":"6","SYSLOG_FACILITY":"3","SYSLOG_IDENTIFIER":"systemd","UNIT":"systemd-tmpfiles-clean.timer","_BOOT_ID":"637573ba91ae4008b58eaa9505a11f86","_CAP_EFFECTIVE":"3fffffffff","_CMDLINE":"/sbin/init","_COMM":"systemd","_EXE":"/lib/systemd/systemd","_GID":"0","_HOSTNAME":"a60c1d059aea","_MACHINE_ID":"48230110dd084e91b7b6885728b98295","_PID":"1","_SOURCE_REALTIME_TIMESTAMP":"1476253700204523","_SYSTEMD_CGROUP":"e","_TRANSPORT":"journal","_UID":"0"},"cursor":"s=f78aeb5184144e2a94963a42b0cac49e;i=262;b=637573ba91ae4008b58eaa9505a11f86;m=6fbb8f76b;t=53ea51966297e;x=69cba0539a7e4576","monotonic_timestamp":29993006955,"realtime_timestamp":1476253700204926}
-```

--- a/1.9/monitoring/logging/logging-api.md
+++ b/1.9/monitoring/logging/logging-api.md
@@ -13,6 +13,15 @@ For more information about using the Logging API, see [Logging](/docs/1.9/monito
 For usage examples, see [Logging API Examples](/docs/1.9/monitoring/logging/logging-api-examples/).
 
 
+# Compatibility
+
+The Logging API preview was added in DC/OS 1.9.0.
+
+Prior to DC/OS 1.9.0, all node, component, and container logs were managed by Logrotate.
+
+In DC/OS 1.9.0, node and component logs are managed by journald. However, the [Mesos task journald log sink was disabled](https://github.com/dcos/dcos/pull/1269) due to [journald performance issues](https://github.com/systemd/systemd/issues/5102). So container log files are still accessible via the [Mesos task sandbox files API](http://mesos.apache.org/documentation/latest/sandbox/).
+
+
 # Routes
 
 Access to the Logging API is proxied through the Admin Router on each node using the following route:


### PR DESCRIPTION
## Description
- Extract the Logging API examples to a new page
  - Update all the examples to use bash, curl, and jq
  - Fix broken examples
  - Remove example output
- Update Logging API swagger
  - Add tags
  - Use markdown in the description

## Urgency
- [ ] Blocker
- [ ] High
- [X] Medium

I tested all these example commands against a dcos-vagrant cluster. 
Several of the old example were broken or wouldn't even execute.