### PR TITLE
Fix minor typo in local-persistent-volume section

### DIFF
--- a/1.9/storage/persistent-volume.md
+++ b/1.9/storage/persistent-volume.md
@@ -45,9 +45,9 @@ You also need to set the `residency` node in order to tell Marathon to setup a s
 ```
 
 <a name="abs-paths"></a>
-### Specifing an unsupported container path
+### Specifying an unsupported container path
 
-The value of `containerPath` must be relative to allow you to dynamically add a local persistent volume to a running container and to ensure consistency across operating systems. However, your application may require an absolute or container path, or a relative one with slashes.
+The value of `containerPath` must be relative to allow you to dynamically add a local persistent volume to a running container and to ensure consistency across operating systems. However, your application may require an absolute container path or a relative one with slashes.
 
 If your application does require an unsupported `containerPath`, configure two volumes. The first volume has the absolute container path you need and does not have the `persistent` parameter. The `hostPath` parameter will match the relative `containerPath` value for the second volume.
 


### PR DESCRIPTION
## Description
<!-- Link to JIRA issue -->
This is a minor typo fix in local persistent volumes document. It doesn't have a corresponding JIRA issue. 
## Urgency
- [ ] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
