### PR TITLE
100,000 ft is arbitrary.

### DIFF
--- a/1.7/overview/architecture.md
+++ b/1.7/overview/architecture.md
@@ -8,11 +8,11 @@ An operating system abstracts resources such as CPU, RAM, and networking and pro
 
 To simplify the understanding of DC/OS, we will reuse the Linux terminology for kernel and user space. The kernel space is a protected area that is not accessible to users and involves low-level operations such as resource allocation, security, and process isolation. The user space is where the user applications and higher order services live, for example the GUI of your OS.
 
-## 100,000 ft view
+## High level overview
 
 The DC/OS kernel space is comprised of Mesos masters and Mesos agents. The user space includes System Components such as Mesos-DNS, Distributed DNS Proxy, and services such as Marathon or Spark. The user space also includes processes that are managed by the services, for example a Marathon application.
 
-![DC/OS architecture 100,000ft view](../img/dcos-architecture-100000ft.png)
+![DC/OS architecture high level overview](../img/dcos-architecture-100000ft.png)
 
 Before we dive into the details of the interaction between different DC/OS components, let's define the terminology used.
 


### PR DESCRIPTION
How does this compare to a 30,000 ft overview? Also, only the US uses feet. High level overview seems more appropriate and global.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala or @joel-hamill for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
