### PR TITLE
No "we" language. DC/OS, not The DC/OS

### DIFF
--- a/1.7/overview/components.md
+++ b/1.7/overview/components.md
@@ -4,9 +4,9 @@ nav_title: Components
 menu_order: 4
 ---
 
-What are the core DC/OS components?
+The Core DC/OS components
 <!--more-->
-By components, we're referring to the services which work together to bring the DC/OS ecosystem alive. The core component is of course [Apache Mesos](http://mesos.apache.org/) but the DC/OS is actually made of of *many* more services than just this.
+DC/OS components are the services which work together to bring the DC/OS ecosystem alive. While the core component is of course [Apache Mesos](http://mesos.apache.org/), DC/OS is actually made of of *many* more services than just this.
 
 If you log into any host in the DC/OS cluster, you can view the currently running services by inspecting `/etc/systemd/system/dcos.target.wants/`.
 


### PR DESCRIPTION
Not sure on your marketing, but DC/OS seems more common than The DC/OS. However, "The DC/OS cluster" is correct because you are describing the specific cluster.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala or @joel-hamill for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
