### PR TITLE
Add missing port 3888

### DIFF
--- a/1.10/installing/ports.md
+++ b/1.10/installing/ports.md
@@ -38,12 +38,13 @@ This topic lists the ports that are required to launch DC/OS. Additional ports m
 | 443   | Admin Router Master | `dcos-adminrouter.service` |
 | 1050  | DC/OS Diagnostics (3DT) | `dcos-3dt.service` |
 | 1801  | DC/OS Authentication | `dcos-oauth.service` |
-| 2181  | Exhibitor and Zookeeper | `dcos-exhibitor.service` |
+| 2181  | Exhibitor and ZooKeeper | `dcos-exhibitor.service` |
+| 3888  | ZooKeeper | `dcos-exhibitor.service` |
 | 5050  | Mesos Master | `dcos-mesos-master.service` |
 | 7070  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` |
 | 8080  | Marathon | `dcos-marathon.service` |
 | 8123  | Mesos DNS | `dcos-mesos-dns.service` |
-| 8181  | Exhibitor and Zookeeper | `dcos-exhibitor.service` |
+| 8181  | Exhibitor and ZooKeeper | `dcos-exhibitor.service` |
 | 9990  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` |
 | 15055 | DC/OS History | `dcos-history-service.service` |
 | 15101 | Marathon libprocess | `dcos-marathon.service` |

--- a/1.9/installing/ports.md
+++ b/1.9/installing/ports.md
@@ -38,12 +38,13 @@ This topic lists the ports that are required to launch DC/OS. Additional ports m
 | 443   | Admin Router Master | `dcos-adminrouter.service` |
 | 1050  | DC/OS Diagnostics (3DT) | `dcos-3dt.service` |
 | 1801  | DC/OS Authentication | `dcos-oauth.service` |
-| 2181  | Exhibitor and Zookeeper | `dcos-exhibitor.service` |
+| 2181  | Exhibitor and ZooKeeper | `dcos-exhibitor.service` |
+| 3888  | ZooKeeper | `dcos-exhibitor.service` |
 | 5050  | Mesos Master | `dcos-mesos-master.service` |
 | 7070  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` |
 | 8080  | Marathon | `dcos-marathon.service` |
 | 8123  | Mesos DNS | `dcos-mesos-dns.service` |
-| 8181  | Exhibitor and Zookeeper | `dcos-exhibitor.service` |
+| 8181  | Exhibitor and ZooKeeper | `dcos-exhibitor.service` |
 | 9990  | DC/OS Package Manager (Cosmos) | `dcos-cosmos.service` |
 | 15055 | DC/OS History | `dcos-history-service.service` |
 | 15101 | Marathon libprocess | `dcos-marathon.service` |


### PR DESCRIPTION
## Description
<!-- Link to JIRA issue -->
https://jira.mesosphere.com/browse/DOCS-1945
- related: https://github.com/mesosphere/dcos-docs-enterprise/pull/1374

## Urgency
- [ ] Blocker <!-- Ping @sascala or @joel-hamill for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
