### PR TITLE
Hopefully fix rendering of code snippet, addresses DOCS-2034

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ Make command installed.
 
 	On MacOS users can run docker commands by default
 	
-    	```bash
-    	make
-    	```
+   	```bash
+   	make
+   	```
 
    **Tip:** This can take up to 15 minutes to complete.
 
@@ -192,13 +192,13 @@ We've implemented the [dcos-docs](https://github.com/dcos/dcos-docs) repo as a [
 
      	```bash
      	sudo yum install -y ruby
-	```
+    	```
 
     -  *MacOS using [Homebrew](http://brew.sh/)*
 
-      	```bash
+    	```bash
       	brew install ruby
-      	```
+    	```
 
 1.  [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DOCS-2034

## Urgency
- [ ] Blocker <!-- Ping @sascala or @joel-hamill for review -->
- [ ] High
- [x ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).

Another fix to README rendering, since the numbering fix one of the code snippets is not formatted properly. It renders correctly in MacDown either way, but on Github the ```bash is visible. I've changed the indenting to three spaces and a tab, which matches the correctly rendering lines, hopefully that fix is correct. 