### PR TITLE
Retitle to remove edge router reference

### DIFF
--- a/1.10/tutorials/dcos-101/marathon-lb.md
+++ b/1.10/tutorials/dcos-101/marathon-lb.md
@@ -1,5 +1,5 @@
 ---
-post_title: Exposing Apps using Edge Router
+post_title: Exposing Apps Publicly
 nav_title: Exposing Apps Publicly
 menu_order: 6
 ---


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DOCS-2064

## Urgency
- [ ] Blocker <!-- Ping @sascala or @stbof for review -->
- [ ] High
- [ x] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).

The 1.10 docs have a reference to edge router in the title, this is confusing with the release of Edge-LB, and this tutorial specifically covers Marathon-LB so revert title to same as 1.9 docs. 