### PR TITLE
Update sample cluster link to use non-url syntax.

### DIFF
--- a/1.10/installing/custom/configuration/configuration-parameters.md
+++ b/1.10/installing/custom/configuration/configuration-parameters.md
@@ -88,7 +88,7 @@ Indicates whether to allow web browsers to send the DC/OS authentication cookie 
 *   `auth_cookie_secure_flag: true` The authentication cookie set by DC/OS will contain the [`Secure` flag](https://www.owasp.org/index.php/SecureFlag), which instructs the browser to not send the cookie over unencrypted HTTP connections. This could cause authentication to fail under the following circumstances.
 
     - If the security mode is `disabled`.
-    - If the security mode is `permissive`, the URL specifies HTTP, and the URL includes a target different from the root path (e.g., http://cluster-url.com/path/).
+    - If the security mode is `permissive`, the URL specifies HTTP, and the URL includes a target different from the root path (e.g., `http://<cluster-url>/<path>/`).
     - There are proxies in between the browser and DC/OS that terminate TLS.
 
 ### bootstrap_url

--- a/1.9/installing/custom/configuration/configuration-parameters.md
+++ b/1.9/installing/custom/configuration/configuration-parameters.md
@@ -82,7 +82,7 @@ Indicates whether to allow web browsers to send the DC/OS authentication cookie 
 *   `auth_cookie_secure_flag: true` The authentication cookie set by DC/OS will contain the [`Secure` flag](https://www.owasp.org/index.php/SecureFlag), which instructs the browser to not send the cookie over unencrypted HTTP connections. This could cause authentication to fail under the following circumstances.
 
     - If the security mode is `disabled`.
-    - If the security mode is `permissive`, the URL specifies HTTP, and the URL includes a target different from the root path (e.g., http://cluster-url.com/path/).
+    - If the security mode is `permissive`, the URL specifies HTTP, and the URL includes a target different from the root path (e.g., `http://<cluster-url>/<path>/`).
     - There are proxies in between the browser and DC/OS that terminate TLS.
 
 ### bootstrap_url


### PR DESCRIPTION
The sample structure becomes more obvious and the link checker does not pick it up.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala or @stbof for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
