### PR TITLE
Add note about Minuteman and Navstar

### DIFF
--- a/1.10/overview/architecture/components.md
+++ b/1.10/overview/architecture/components.md
@@ -469,6 +469,7 @@ In a world where machines are are given numbers instead of names, tasks are sche
 <h2 id="minuteman">Minuteman</h2>
 <div>
 <p><strong>Description:</strong> Minuteman provides distributed <a href="https://en.wikipedia.org/wiki/Transport_layer">Layer 4</a> virtual IP load balancing.</p>
+<p><strong>Note:</strong> Minuteman and Navstar run on a shared Erlang Virtual Machine which is supervised by systemd. So only Navstar appears in the systemd service list and component UI.</p>
 <p>
   <strong>System Service(s):</strong>
   <ul>


### PR DESCRIPTION
Don't remove minuteman, because it'll be back for 1.11. 

In 1.11 all the networking Erlang components will be refactored to run as applications on the same Erlang VM but with watchdog processes to do readiness checks. Those watchdogs will have new names and show up in the component list.