### PR TITLE
Update tweeter IoT tutorials to point to new versioned directories

### DIFF
--- a/1.8/usage/tutorials/iot_pipeline.md
+++ b/1.8/usage/tutorials/iot_pipeline.md
@@ -64,7 +64,7 @@ In this step you deploy the containerized Tweeter app to a public node.
     git clone git@github.com:mesosphere/tweeter.git
     ```
 
-2.  Add the `HAPROXY_0_VHOST` label to the `tweeter.json` Marathon app definition file. `HAPROXY_0_VHOST` exposes Nginx on the external load balancer with a virtual host. The `HAPROXY_0_VHOST` value is the hostname of your [public agent][9] node. 
+2.  Add the `HAPROXY_0_VHOST` label to the `1.8/tweeter.json` Marathon app definition file. `HAPROXY_0_VHOST` exposes Nginx on the external load balancer with a virtual host. The `HAPROXY_0_VHOST` value is the hostname of your [public agent][9] node. 
 
     **Important:** You must remove the leading `http://` and the trailing `/`. 
     
@@ -91,7 +91,7 @@ In this step you deploy the containerized Tweeter app to a public node.
 4.  Install and deploy Tweeter with this command.
     
     ```bash
-    dcos marathon app add tweeter.json
+    dcos marathon app add 1.8/tweeter.json
     ```
     
     **Tip:** The `instances` parameter in `tweeter.json` specifies the number of app instances. Use the following command to scale your app up or down:
@@ -108,9 +108,9 @@ In this step you deploy the containerized Tweeter app to a public node.
 
 # Post 100K Tweets
 
-Use the `post-tweets.json` app a large number of Shakespeare tweets from a file:
+Use the `1.8/post-tweets.json` app a large number of Shakespeare tweets from a file:
 
-        dcos marathon app add post-tweets.json
+        dcos marathon app add 1.8/post-tweets.json
     
 
 The app will post more than 100k tweets one by one, so you'll see them coming in steadily when you refresh the page. Click the **Network** tab in the DC/OS web interface to see the load balancing in action.
@@ -121,7 +121,7 @@ The post-tweets app works by streaming to the VIP `1.1.1.1:30000`. This address 
 
 Next, you'll perform real-time analytics on the stream of tweets coming in from Kafka.
 
-1.  Navigate to Zeppelin at `https://<master_ip>/service/zeppelin/`, click **Import Note** and import `tweeter-analytics.json`. Zeppelin is preconfigured to execute Spark jobs on the DC/OS cluster, so there is no further configuration or setup required. Be sure to use `https://`, not `http://`.
+1.  Navigate to Zeppelin at `https://<master_ip>/service/zeppelin/`, click **Import Note** and import `1.8/tweeter-analytics.json`. Zeppelin is preconfigured to execute Spark jobs on the DC/OS cluster, so there is no further configuration or setup required. Be sure to use `https://`, not `http://`.
     
     **Tip:** Your master IP address is the URL of the DC/OS web interface.
 

--- a/1.9/tutorials/iot_pipeline.md
+++ b/1.9/tutorials/iot_pipeline.md
@@ -68,7 +68,7 @@ __Tip:__ You can also install DC/OS packages from the DC/OS CLI with the [`dcos 
 
 In this step you deploy the containerized Tweeter app to a public node.
 
-1.  Navigate to the [Tweeter](https://github.com/mesosphere/tweeter/) GitHub repository and save the `/tweeter/tweeter.json` Marathon app definition file. 
+1.  Navigate to the [Tweeter](https://github.com/mesosphere/tweeter/) GitHub repository and save the `/tweeter/1.9/tweeter.json` Marathon app definition file. 
 
 1.  Add the `HAPROXY_0_VHOST` definition with the public IP address of your [public agent][9] node to your `tweeter.json` file. 
 
@@ -122,7 +122,7 @@ In this step you deploy the containerized Tweeter app to a public node.
 
 Deploy the post-tweets containerized app to see DC/OS load balancing in action. This app automatically posts a large number of tweets from Shakespeare. The app will post more than 100k tweets one by one, so you'll see them coming in steadily when you refresh the page. 
 
-1.  Navigate to the [Tweeter](https://github.com/mesosphere/tweeter/) GitHub repository and save the `tweeter/post-tweets.json` Marathon app definition file. 
+1.  Navigate to the [Tweeter](https://github.com/mesosphere/tweeter/) GitHub repository and save the `tweeter/1.9/post-tweets.json` Marathon app definition file. 
 
 1.  Deploy the `post-tweets.json` Marathon app definition file. 
 
@@ -166,7 +166,7 @@ The Tweeter app uses the service discovery and load balancer service that is ins
 
 Next, you'll perform real-time analytics on the stream of tweets coming in from Kafka.
 
-1.  Navigate to Zeppelin at `https://<master_ip>/service/zeppelin/`, click **Import Note** and import `tweeter-analytics.json`. Zeppelin is preconfigured to execute Spark jobs on the DC/OS cluster, so there is no further configuration or setup required. Be sure to use `https://`, not `http://`.
+1.  Navigate to Zeppelin at `https://<master_ip>/service/zeppelin/`, click **Import Note** and import `1.9/tweeter-analytics.json`. Zeppelin is preconfigured to execute Spark jobs on the DC/OS cluster, so there is no further configuration or setup required. Be sure to use `https://`, not `http://`.
     
     **Tip:** Your master IP address is the URL of the DC/OS web interface.
 


### PR DESCRIPTION
## Description
Update for https://jira.mesosphere.com/browse/DOCS-2112

Tweeter repository versions the app definitions now. Updated the paths to specify that the ones corresponding to the DC/OS versions for 1.8 and 1.9 should be used. 1.10 and 1.11 work with the top-level tweeter files so those do not need to be changed.

## Urgency
- [ ] Blocker <!-- Ping @sascala or @stbof for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
