### PR TITLE
Update the API route docs for 1.10

### DIFF
--- a/1.10/api/nginx.agent.html
+++ b/1.10/api/nginx.agent.html
@@ -107,7 +107,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/component-management/">https://dcos.io/docs/1.10/administration/component-management/</a>
+                  <a href="https://dcos.io/docs/1.10/administering-clusters/component-management/">https://dcos.io/docs/1.10/administering-clusters/component-management/</a>
                 </td>
               </tr>
             </table>
@@ -163,7 +163,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint</a>
+                  <a href="https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint</a>
                 </td>
               </tr>
             </table>
@@ -208,7 +208,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/logging/logging-api/">https://dcos.io/docs/1.10/administration/logging/logging-api/</a>
+                  <a href="https://dcos.io/docs/1.10/monitoring/logging/logging-api/">https://dcos.io/docs/1.10/monitoring/logging/logging-api/</a>
                 </td>
               </tr>
             </table>
@@ -253,7 +253,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/">https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/</a>
+                  <a href="https://dcos.io/docs/1.10/metrics/metrics-api/">https://dcos.io/docs/1.10/metrics/metrics-api/</a>
                 </td>
               </tr>
             </table>

--- a/1.10/api/nginx.master.html
+++ b/1.10/api/nginx.master.html
@@ -196,7 +196,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/</a>
+                  <a href="https://dcos.io/docs/1.10/security/iam-api/">https://dcos.io/docs/1.10/security/iam-api/</a>
                 </td>
               </tr>
             </table>
@@ -241,7 +241,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/</a>
+                  <a href="https://dcos.io/docs/1.10/security/iam-api/">https://dcos.io/docs/1.10/security/iam-api/</a>
                 </td>
               </tr>
             </table>
@@ -823,7 +823,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/">https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/</a>
+                  <a href="https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/">https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/</a>
                 </td>
               </tr>
             </table>
@@ -921,7 +921,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/</a>
+                  <a href="https://dcos.io/docs/1.10/security/iam-api/">https://dcos.io/docs/1.10/security/iam-api/</a>
                 </td>
               </tr>
             </table>
@@ -1044,7 +1044,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/">https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/</a>
+                  <a href="https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/">https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/</a>
                 </td>
               </tr>
             </table>
@@ -1132,7 +1132,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/component-management/">https://dcos.io/docs/1.10/administration/component-management/</a>
+                  <a href="https://dcos.io/docs/1.10/administering-clusters/component-management/">https://dcos.io/docs/1.10/administering-clusters/component-management/</a>
                 </td>
               </tr>
             </table>
@@ -1241,7 +1241,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint</a>
+                  <a href="https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint</a>
                 </td>
               </tr>
             </table>
@@ -1391,7 +1391,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/logging/logging-api/">https://dcos.io/docs/1.10/administration/logging/logging-api/</a>
+                  <a href="https://dcos.io/docs/1.10/monitoring/logging/logging-api/">https://dcos.io/docs/1.10/monitoring/logging/logging-api/</a>
                 </td>
               </tr>
             </table>
@@ -1436,7 +1436,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/">https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/</a>
+                  <a href="https://dcos.io/docs/1.10/metrics/metrics-api/">https://dcos.io/docs/1.10/metrics/metrics-api/</a>
                 </td>
               </tr>
             </table>


### PR DESCRIPTION
## Description
Used the script I wrote last time. Yay automation!
Only changes are to use the real 1.10 urls instead of depending on redirects.

## Urgency
- [ ] Blocker <!-- Ping @sascala or @stbof for review -->
- [ ] High
- [X] Medium
