### PR TITLE
Fix config.yaml for custom advanced install

### DIFF
--- a/1.10/installing/custom/advanced.md
+++ b/1.10/installing/custom/advanced.md
@@ -74,14 +74,8 @@ Your cluster must meet the software and hardware [requirements](/docs/1.10/insta
 
     ```yaml
     ---
-    agent_list:
-    - <agent-private-ip-1>
-    - <agent-private-ip-2>
-    - <agent-private-ip-3>
-    - <agent-private-ip-4>
-    - <agent-private-ip-5>
     # Use this bootstrap_url value unless you have moved the DC/OS installer assets.
-    bootstrap_url: file:///opt/dcos_install_tmp
+    bootstrap_url: http://<bootstrap_ip>:<your_port>
     cluster_name: <cluster-name>
     exhibitor_storage_backend: static
     master_discovery: static
@@ -90,13 +84,9 @@ Your cluster must meet the software and hardware [requirements](/docs/1.10/insta
     - <master-private-ip-1>
     - <master-private-ip-2>
     - <master-private-ip-3>
-    public_agent_list:
-    - <public-agent-private-ip>
     resolvers:
     - 8.8.4.4
     - 8.8.8.8
-    ssh_port: 22
-    ssh_user: <username>
     use_proxy: 'true'
     http_proxy: http://<proxy_host>:<http_proxy_port>
     https_proxy: https://<proxy_host>:<https_proxy_port>

--- a/1.9/installing/custom/advanced.md
+++ b/1.9/installing/custom/advanced.md
@@ -74,14 +74,8 @@ Your cluster must meet the software and hardware [requirements](/docs/1.9/instal
 
     ```yaml
     ---
-    agent_list:
-    - <agent-private-ip-1>
-    - <agent-private-ip-2>
-    - <agent-private-ip-3>
-    - <agent-private-ip-4>
-    - <agent-private-ip-5>
     # Use this bootstrap_url value unless you have moved the DC/OS installer assets.
-    bootstrap_url: file:///opt/dcos_install_tmp
+    bootstrap_url: http://<bootstrap_ip>:<your_port>
     cluster_name: <cluster-name>
     exhibitor_storage_backend: static
     master_discovery: static
@@ -90,13 +84,9 @@ Your cluster must meet the software and hardware [requirements](/docs/1.9/instal
     - <master-private-ip-1>
     - <master-private-ip-2>
     - <master-private-ip-3>
-    public_agent_list:
-    - <public-agent-private-ip>
     resolvers:
     - 8.8.4.4
     - 8.8.8.8
-    ssh_port: 22
-    ssh_user: <username>
     use_proxy: 'true'
     http_proxy: http://<proxy_host>:<http_proxy_port>
     https_proxy: https://<proxy_host>:<https_proxy_port>


### PR DESCRIPTION
## Description

Unless I'm missing something the config.yaml sample on custom advanced install page is incorrect and has been broken for a while (since https://github.com/dcos/dcos-docs/commit/e42d9b1e1d55df15a6117ded47f4c41de3736490)

Problems with the config.yaml :
**Major problem :**
bootstrap_url is set to file:///opt/dcos_install_tmp instead of `bootstrap_url: http://<bootstrap_ip>:<your_port>`

**Minor Problems:**
`agent_list`, `public_agent_list`, `ssh_port` and `ssh_user` are irrelevant for Advanced custom install method and should be removed

https://jira.mesosphere.com/browse/DCOS_OSS-1754

## Urgency
- [X] Blocker <!-- Ping @sascala or @stbof for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, and 1.10).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).

@sascala @stbof Please review