### PR TITLE
Document CLI version requirements for DC/OS <=1.9

### DIFF
--- a/1.7/usage/cli/index.md
+++ b/1.7/usage/cli/index.md
@@ -4,7 +4,7 @@ nav_title: CLI
 menu_order: 10
 ---
 
-**Important:** DC/OS 1.8 introduces binary CLIs for Linux, Windows, and Mac. The install script is replaced with a simple binary CLI. The 1.8 CLI is compatible with DC/OS 1.6.1 forward. For more information, see the [documentation](/docs/1.7/usage/cli/install/).
+**Important:** DC/OS 1.8 introduces binary CLIs for Linux, Windows, and Mac. The install script is replaced with a simple binary CLI. The 1.8 CLI (version 0.4.x) is compatible with DC/OS 1.7, 1.8, and 1.9. For more information, see the [documentation](/docs/1.7/usage/cli/install/).
 
 You can use the DC/OS command-line interface (CLI) to manage your cluster nodes, install DC/OS packages, inspect the cluster state, and administer the DC/OS service subcommands. You can install the CLI from the DC/OS web interface.
 

--- a/1.8/usage/cli/index.md
+++ b/1.8/usage/cli/index.md
@@ -8,6 +8,8 @@ You can use the DC/OS command-line interface (CLI) to manage your cluster nodes,
 
 You can quickly [install](/docs/1.8/usage/cli/install) the CLI from the DC/OS web interface.
 
+DC/OS 1.8.0 requires DC/OS CLI 0.4.x.
+
 To list available commands, either run `dcos` with no parameters or run `dcos help`:
 
 ```bash

--- a/1.9/cli/index.md
+++ b/1.9/cli/index.md
@@ -8,6 +8,8 @@ You can use the DC/OS command-line interface (CLI) to manage your cluster nodes,
 
 You can quickly [install](/docs/1.9/cli/install) the CLI from the DC/OS web interface.
 
+DC/OS 1.9.0 requires DC/OS CLI 0.4.x.
+
 To list available commands, either run `dcos` with no parameters or run `dcos help`:
 
 ```bash


### PR DESCRIPTION
The CLI versions requirements are:

DC/OS <=1.9: CLI 0.4.x
DC/OS  1.10: CLI 0.5.x
DC/OS  1.11: CLI 0.6.x

## Description
https://jira.mesosphere.com/browse/DCOS-37542

## Urgency
- [ ] Blocker <!-- Ping @sascala or @stbof for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-docs#test-local) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, 1.9, and 1.10).
- See the [contribution guidelines](https://github.com/dcos/dcos-docs#contributing).
